### PR TITLE
Unnecessary trailing slashes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 global-include *.txt Makefile *.py *.rst *.ini
-prune env26/
-prune .tox/
-prune docs/_build/
-prune docs/_themes/
+prune env26
+prune .tox
+prune docs/_build
+prune docs/_themes


### PR DESCRIPTION
Unnecessary trailing slashes don't allow to install module on Windows environment
