### PR TITLE
Don't call `setUser` on transaction if there is no user logged in.  This...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 nosetests.xml
 pyramid_tm/coverage.xml
 env*/
+venv/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+- Don't call `setUser` on transaction if there is no user logged in.  This could
+  cause the username set on the transaction to be a strange string: " None".
+
 0.7 (2012-12-30)
 ----------------
 

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -58,7 +58,8 @@ def tm_tween_factory(handler, registry, transaction=transaction):
                 if attempts != 1:
                     request.make_body_seekable()
                 t = manager.get()
-                t.setUser(userid, '')
+                if userid:
+                    t.setUser(userid, '')
                 t.note(request.path_info)
                 response = handler(request)
                 if manager.isDoomed():

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -56,7 +56,7 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.request = DummyRequest()
         self.response = DummyResponse()
         self.registry = DummyRegistry()
-        
+
     def _callFUT(self, handler=None, registry=None, request=None, txn=None):
         if handler is None:
             def handler(request):
@@ -114,7 +114,7 @@ class Test_tm_tween_factory(unittest.TestCase):
         def handler(request, count=count):
             raise Conflict
         self.assertRaises(Conflict, self._callFUT, handler=handler)
-        
+
     def test_handler_isdoomed(self):
         txn = DummyTransaction(True)
         self._callFUT(txn=txn)
@@ -229,6 +229,7 @@ class DummyTransaction(TransactionManager):
     committed = False
     aborted = False
     _resources = []
+    username = None
 
     def __init__(self, doomed=False, retryable=False):
         self.doomed = doomed
@@ -248,7 +249,7 @@ class DummyTransaction(TransactionManager):
         return self
 
     def setUser(self, name, path='/'):
-        self.username = name
+        self.username = "%s %s" % (path, name)
 
     def isDoomed(self):
         return self.doomed


### PR DESCRIPTION
... could

cause the username set on the transaction to be a strange string: " None".
