### PR TITLE
ZODB expect userid and description to be bytes

### DIFF
--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -62,8 +62,8 @@ def tm_tween_factory(handler, registry, transaction=transaction):
                     request.make_body_seekable()
                 t = manager.get()
                 if userid:
-                    t.setUser(userid, '')
-                t.note(request.path_info)
+                    t.setUser(userid.encode('utf-8'), '')
+                t.note(request.path_info.encode('utf-8'))
                 response = handler(request)
                 if manager.isDoomed():
                     raise AbortResponse(response)


### PR DESCRIPTION
ZODB expect user and description to be bytes.

as in ZODB/FileStorage/format.py

``` python
def asString(self):
        s = struct.pack(TRANS_HDR, self.tid, self.tlen, as_bytes(self.status),
                        self.ulen, self.dlen, self.elen)
        return b"".join(map(as_bytes, [s, self.user, self.descr, self.ext]))
```

Chinese username or pathinfo will throw an exception here.
