### PR TITLE
Enable overriding the transaction manager for each request

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,3 +106,4 @@ Contributors
 - Gavin Carothers, 2014/11/11
 - Chris McDonough, 2014/11/12
 - Chris Rossi, 2014/11/20
+- Donald Stufft, 2015/02/02

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,3 +11,5 @@
 
 .. autofunction:: tm_tween_factory
 
+.. autofunction:: create_tm
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,40 @@ well as SQLAlchemy connections which are configured with the
 ``ZopeTransactionExtension`` extension from the `zope.sqlalchemy
 <https://pypi.python.org/pypi/zope.sqlalchemy>`_ package.
 
+
+Custom Transaction Managers
+---------------------------
+
+By default ``pyramid_tm`` will use the default transaction manager which uses
+thread locals to associate one transaction manager per thread. If you wish
+to override this and provide your own transaction manager you can create your
+own manager hook that will return the manager it should use.
+
+.. code-block:: python
+   :linenos:
+
+   import transaction
+
+   def manager_hook(request):
+       return transaction.TransactionManager()
+
+To enable this hook, add it as the ``tm.manager_hook`` setting in your app.
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.config import Configurator
+
+   def app(global_conf, **settings):
+       settings['tm.manager_hook'] = manager_hook
+       config = Configurator(settings=settings)
+       config.include('pyramid_tm')
+       # ...
+
+The current transaction manager being used for any particular request can
+always be accessed on the request as ``request.transaction``.
+
+
 Adding an Activation Hook
 -------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,7 +114,7 @@ To enable this hook, add it as the ``tm.manager_hook`` setting in your app.
        # ...
 
 The current transaction manager being used for any particular request can
-always be accessed on the request as ``request.transaction``.
+always be accessed on the request as ``request.tm``.
 
 
 Adding an Activation Hook

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -30,8 +30,7 @@ class AbortResponse(Exception):
     def __init__(self, response):
         self.response = response
 
-def tm_tween_factory(handler, registry, transaction=transaction):
-    # transaction parameterized for testing purposes
+def tm_tween_factory(handler, registry):
     old_commit_veto = registry.settings.get('pyramid_tm.commit_veto', None)
     commit_veto = registry.settings.get('tm.commit_veto', old_commit_veto)
     activate = registry.settings.get('tm.activate_hook')
@@ -49,7 +48,7 @@ def tm_tween_factory(handler, registry, transaction=transaction):
             if not activate(request):
                 return handler(request)
 
-        manager = transaction.manager
+        manager = request.transaction
         number = attempts
         if hasattr(request, 'unauthenticated_userid'):
             userid = request.unauthenticated_userid
@@ -98,6 +97,16 @@ def tm_tween_factory(handler, registry, transaction=transaction):
 
     return tm_tween
 
+
+def create_tm(request):
+    manager_hook = request.registry.settings.get('tm.manager_hook')
+    if manager_hook:
+        manager_hook = resolver.maybe_resolve(manager_hook)
+        return manager_hook(request)
+    else:
+        return transaction.manager
+
+
 def includeme(config):
     """
     Set up am implicit 'tween' to do transaction management using the
@@ -126,4 +135,7 @@ def includeme(config):
     - If none of the above conditions are True, the transaction will be
       committed (via ``transaction.commit()``).
     """
+    config.add_request_method(
+        'pyramid_tm.create_tm', name='transaction', reify=True,
+    )
     config.add_tween('pyramid_tm.tm_tween_factory', under=EXCVIEW)

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import transaction
 
+from pyramid.exceptions import ConfigurationError
 from pyramid.util import DottedNameResolver
 from pyramid.tweens import EXCVIEW
 
@@ -139,3 +140,14 @@ def includeme(config):
         'pyramid_tm.create_tm', name='transaction', reify=True,
     )
     config.add_tween('pyramid_tm.tm_tween_factory', under=EXCVIEW)
+
+    def ensure():
+        manager_hook = config.registry.settings.get("tm.manager_hook")
+        if manager_hook is not None:
+            try:
+                manager_hook = resolver.maybe_resolve(manager_hook)
+                config.registry.settings["tm.manager_hook"] = manager_hook
+            except (ImportError, ValueError):
+                raise ConfigurationError("Unable to resolve tm.manager_hook")
+
+    config.action(None, ensure, order=10)


### PR DESCRIPTION
Fixes #30 by adding a hook ``tm.manager_hook`` which takes the current request as an argument and returns the ``ITransactionManager`` to be used for this request, continuing to default to the thread local transaction mananger. It also adds a new request property (``request.transaction``) which allows accessing the given ``ITransactionMananger`` for this particular request.