### PR TITLE
Make annotating the transaction with user optional

### DIFF
--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -37,6 +37,7 @@ def tm_tween_factory(handler, registry):
     attempts = int(registry.settings.get('tm.attempts', 1))
     commit_veto = resolver.maybe_resolve(commit_veto) if commit_veto else None
     activate = resolver.maybe_resolve(activate) if activate else None
+    annotate_user = registry.settings.get("tm.annotate_user", True)
     assert attempts > 0
 
     def tm_tween(request):
@@ -50,11 +51,14 @@ def tm_tween_factory(handler, registry):
 
         manager = request.tm
         number = attempts
-        if hasattr(request, 'unauthenticated_userid'):
-            userid = request.unauthenticated_userid
-        else: #pragma NO COVER deprecated
-            from pyramid.security import unauthenticated_userid
-            userid = unauthenticated_userid(request)
+        if annotate_user:
+            if hasattr(request, 'unauthenticated_userid'):
+                userid = request.unauthenticated_userid
+            else: #pragma NO COVER deprecated
+                from pyramid.security import unauthenticated_userid
+                userid = unauthenticated_userid(request)
+        else:
+            userid = None
 
         while number:
             number -= 1

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -169,6 +169,12 @@ class Test_tm_tween_factory(unittest.TestCase):
         self._callFUT()
         self.assertEqual(self.txn.username, ' 1234')
 
+    def test_disables_user_annotation(self):
+        self.config.testing_securitypolicy(userid="nope")
+        registry = DummyRegistry({"tm.annotate_user": False})
+        result = self._callFUT(registry=registry)
+        self.assertEqual(self.txn.username, None)
+
     def test_handler_notes(self):
         self._callFUT()
         self.assertEqual(self.txn._note, '/')


### PR DESCRIPTION
In Warehouse I have the the AuthenticationPolicy's adding a ``Vary: Cookie`` so that any access to the user ensures that we make the response varied by cookie. We do this because we assume that if you're accessing the user you're going to do something different based on that information and we need to vary it.

This however doesn't work because pyramid_tm assumes it can access ``request.unauthenticated_user`` on every request to annotate the transaction with a particular user. I don't believe I need this functionality in Warehouse so I'd love a knob to turn off that behavior.