### PR TITLE
place the tm over excview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,6 @@ matrix:
           env: TOXENV=py2-cover,py3-cover,coverage
         - python: 3.5
           env: TOXENV=docs
-        - python: 2.7
-          env: TOXENV=py27-pyramid12
-        - python: 2.7
-          env: TOXENV=py27-pyramid13
-        - python: 2.7
-          env: TOXENV=py27-pyramid14
-        - python: 2.7
-          env: TOXENV=py27-pyramid15
-        - python: 3.5
-          env: TOXENV=py35-pyramid16
         - python: 3.5
           env: TOXENV=py35-pyramid17
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,3 +13,10 @@
 
 .. autofunction:: create_tm
 
+.. autofunction:: is_exc_retryable
+
+.. autofunction:: is_last_attempt
+
+.. autoclass:: LastAttemptPredicate
+
+.. autoclass:: RetryableExceptionPredicate

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -9,8 +9,20 @@ Glossary
    Pyramid
       A `web framework <http://pylonshq.com/pyramid>`_.
 
+   data manager
+      The ``transaction`` package wraps data managers implemented for
+      different transactional backends, such as SQLAlchemy
+      (``zope.sqlalchemy``), but also many others.
+
+   retryable
+      A retryable exception is any exception that is recognized as retryable
+      by an active :term:`data manager`. These errors usually inherit from
+      ``transaction.interfaces.TransientError``. These errors are temporary
+      and thus marked as retryable. For example, a serialization error in a
+      database resulting from concurrent transactions.
+
    transaction
       A database transaction comprises a unit of work performed within a
       database management system.  In the context of the Pyramid documentation,
-      "transaction" is also the name of a `Python package 
-      <http://pypi.python.org/pypi/transaction>`_ used by pyramid_tm.
+      "transaction" is also the name of a `Python package
+      <http://pypi.python.org/pypi/transaction>`__ used by ``pyramid_tm``.

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -55,17 +55,10 @@ def tm_tween_factory(handler, registry):
         # Set a flag in the environment to enable the `request.tm` property.
         request.environ['tm.active'] = True
 
-        manager = getattr(request, 'tm', None)
-        if manager is None: # pragma: no cover (pyramid < 1.4)
-            manager = create_tm(request)
-            request.tm = manager
+        manager = request.tm
         number = attempts
         if annotate_user:
-            if hasattr(request, 'unauthenticated_userid'):
-                userid = request.unauthenticated_userid
-            else: # pragma no cover (for pyramid < 1.5)
-                from pyramid.security import unauthenticated_userid
-                userid = unauthenticated_userid(request)
+            userid = request.unauthenticated_userid
         else:
             userid = None
 
@@ -153,14 +146,7 @@ def includeme(config):
     - If none of the above conditions are True, the transaction will be
       committed (via ``transaction.commit()``).
     """
-    # pyramid 1.4+
-    if hasattr(config, 'add_request_method'):
-        config.add_request_method(
-            'pyramid_tm.create_tm', name='tm', reify=True)
-    # pyramid 1.3
-    elif hasattr(config, 'set_request_property'): # pragma: no cover
-        config.set_request_property(
-            'pyramid_tm.create_tm', name='tm', reify=True)
+    config.add_request_method('pyramid_tm.create_tm', name='tm', reify=True)
     config.add_tween('pyramid_tm.tm_tween_factory', under=EXCVIEW)
 
     def ensure():

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -1,14 +1,20 @@
 import sys
 import transaction
 
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.interfaces import IRequestExtensions
+from pyramid.interfaces import IRequestFactory
+from pyramid.request import Request, apply_request_extensions
 from pyramid.settings import asbool
-from pyramid.util import DottedNameResolver
+from pyramid.threadlocal import manager as request_manager
 from pyramid.tweens import EXCVIEW
+from pyramid.util import DottedNameResolver
 
 from pyramid_tm.compat import reraise
 from pyramid_tm.compat import native_
 
 resolver = DottedNameResolver(None)
+
 
 def default_commit_veto(request, response):
     """
@@ -27,18 +33,24 @@ def default_commit_veto(request, response):
         return xtm != 'commit'
     return response.status.startswith(('4', '5'))
 
-class AbortResponse(Exception):
+
+class AbortWithResponse(Exception):
+    """ Abort the transaction but return a pre-baked response."""
     def __init__(self, response):
         self.response = response
 
+
 def tm_tween_factory(handler, registry):
-    old_commit_veto = registry.settings.get('pyramid_tm.commit_veto', None)
-    commit_veto = registry.settings.get('tm.commit_veto', old_commit_veto)
-    activate = registry.settings.get('tm.activate_hook')
-    attempts = int(registry.settings.get('tm.attempts', 1))
+    settings = registry.settings
+    old_commit_veto = settings.get('pyramid_tm.commit_veto', None)
+    commit_veto = settings.get('tm.commit_veto', old_commit_veto)
+    activate = settings.get('tm.activate_hook')
+    attempts = int(settings.get('tm.attempts', 1))
     commit_veto = resolver.maybe_resolve(commit_veto) if commit_veto else None
     activate = resolver.maybe_resolve(activate) if activate else None
-    annotate_user = asbool(registry.settings.get("tm.annotate_user", True))
+    annotate_user = asbool(settings.get('tm.annotate_user', True))
+    request_factory = registry.queryUtility(IRequestFactory, default=Request)
+    request_extensions = registry.queryUtility(IRequestExtensions)
     assert attempts > 0
 
     def tm_tween(request):
@@ -52,58 +64,219 @@ def tm_tween_factory(handler, registry):
         ):
             return handler(request)
 
-        # Set a flag in the environment to enable the `request.tm` property.
-        request.environ['tm.active'] = True
+        # if we are supporting multiple attempts then we must make
+        # make the body seekable in order to re-use it across multiple
+        # attempts. make_body_seekable will copy wsgi.input if
+        # necessary, otherwise it will rewind the copy to position zero
+        if attempts != 1:
+            request.make_body_seekable()
 
-        manager = request.tm
-        number = attempts
-        if annotate_user:
-            userid = request.unauthenticated_userid
-        else:
-            userid = None
+        # hang onto a reference to the original request as it's the thing
+        # used above the tm tween, we can't change that
+        orig_request = request
+        manager = None
 
-        while number:
-            number -= 1
+        for number in range(attempts):
+            is_last_attempt = (number == attempts - 1)
+
+            # track the attempt info in the environ
+            # try to set it as soon as possible so that it's available
+            # in the request factory and elsewhere if people want it
+            # note: set all of these values here as they are cleared after
+            # each attempt
+            environ = request.environ
+            environ['tm.active'] = True
+            environ['tm.attempt'] = number
+            environ['tm.attempts'] = attempts
+
+            # do not touch request.tm until we've set it active or it'll raise
+            if manager is None:
+                manager = request.tm
+
+            # if we are not on the first attempt then we should start
+            # with a new request object and throw away any changes to
+            # the old object, however we do this carefully to try and
+            # avoid extra copies of the body
+            if number > 0:
+                # try to make sure this code stays in sync with pyramid's
+                # router which normally creates requests
+                request = request_factory(environ)
+                request.tm = manager
+                request.registry = registry
+                request.invoke_subrequest = orig_request.invoke_subrequest
+                apply_request_extensions(request, extensions=request_extensions)
+
+            # push the new request onto the threadlocal stack
+            # this should be safe unless someone is doing something
+            # really funky
+            request_manager.push({
+                'request': request,
+                'registry': registry,
+            })
+
             try:
-                manager.begin()
-                # make_body_seekable will copy wsgi.input if necessary,
-                # otherwise it will rewind the copy to position zero
-                if attempts != 1:
-                    request.make_body_seekable()
-                t = manager.get()
-                if userid:
-                    userid = native_(userid, 'utf-8')
-                    t.setUser(userid, '')
+                t = manager.begin()
+
+                # do not address the authentication policy until we are within
+                # the transaction boundaries
+                if annotate_user:
+                    userid = request.unauthenticated_userid
+                    if userid:
+                        userid = native_(userid, 'utf-8')
+                        t.setUser(userid, '')
                 try:
                     t.note(native_(request.path_info, 'utf-8'))
                 except UnicodeDecodeError:
                     t.note("Unable to decode path as unicode")
+
                 response = handler(request)
                 if manager.isDoomed():
-                    raise AbortResponse(response)
+                    raise AbortWithResponse(response)
+
+                # check for a squashed exception and handle it
+                # this would happen if an exception view was invoked and
+                # rendered an error response
+                exc_info = getattr(request, 'exc_info', None)
+                if exc_info is not None:
+                    # if this was the last attempt or the exception is not
+                    # retryable use this response instead of raising and
+                    # having a new error response generated
+                    if (
+                        is_last_attempt or
+                        not is_exc_retryable(request, exc_info)
+                    ):
+                        raise AbortWithResponse(response)
+
+                    # the exception is retryable so we'll squash the response
+                    # and loop around to try again
+                    else:
+                        reraise(*exc_info)
+
                 if commit_veto is not None:
                     veto = commit_veto(request, response)
                     if veto:
-                        raise AbortResponse(response)
+                        raise AbortWithResponse(response)
                 manager.commit()
-                del request.environ['tm.active']
                 return response
-            except AbortResponse as e:
+
+            except AbortWithResponse as e:
                 manager.abort()
-                del request.environ['tm.active']
                 return e.response
-            except:
+
+            except Exception:
                 exc_info = sys.exc_info()
                 try:
-                    retryable = manager._retryable(*exc_info[:-1])
-                    manager.abort()
-                    if (number <= 0) or (not retryable):
-                        del request.environ['tm.active']
-                        reraise(*exc_info)
+                    # if this was the last attempt or the exception is not
+                    # retryable then make a last ditch effort to render an
+                    # error response before sending the exception up the stack
+                    if (
+                        is_last_attempt or
+                        not is_exc_retryable(request, exc_info)
+                    ):
+                        return render_exception(request, exc_info)
+
                 finally:
+                    # keep the manager alive until after invoke_exception_view
+                    manager.abort()
+
                     del exc_info # avoid leak
 
+            # cleanup any changes we made to the request
+            finally:
+                request_manager.pop()
+
+                del environ['tm.active']
+                del environ['tm.attempt']
+                del environ['tm.attempts']
+
+                # propagate exception info back to the original request,
+                # possibly clearing out a retryable error triggered from the
+                # first attempt
+                orig_request.exception = getattr(request, 'exception', None)
+                orig_request.exc_info = getattr(request, 'exc_info', None)
+
     return tm_tween
+
+
+def render_exception(request, exc_info):
+    try:
+        return request.invoke_exception_view(exc_info)
+    except HTTPNotFound:
+        reraise(*exc_info)
+
+
+def is_exc_retryable(request, exc_info):
+    """
+    Return ``True`` if the exception is recognized as :term:`retryable`.
+
+    This will return ``False`` if ``pyramid_tm`` is inactive for the request.
+
+    """
+    if not request.environ.get('tm.active', False):
+        return False
+    if exc_info is None:
+        return False
+    return request.tm._retryable(*exc_info[:-1])
+
+
+def is_last_attempt(request):
+    """
+    Return ``True`` if the ``request`` is being executed as the last
+    attempt, meaning that ``pyramid_tm`` will not be issuing any new attempts,
+    regardless of what happens when executing this request.
+
+    This will return ``True`` if ``pyramid_tm`` is inactive for the request.
+
+    """
+    environ = request.environ
+    if not environ.get('tm.active', False):
+        return True
+
+    return environ['tm.attempt'] == environ['tm.attempts'] - 1
+
+
+class RetryableExceptionPredicate(object):
+    """
+    A :term:`view predicate` registered as ``tm_exc_is_retryable``. Can be
+    used to determine if an exception view should execute based on whether
+    the exception is :term:`retryable`.
+
+    """
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'tm_exc_is_retryable = %s' % (self.val,)
+
+    phash = text
+
+    def __call__(self, context, request):
+        exc_info = getattr(request, 'exc_info', None)
+        is_retryable = is_exc_retryable(request, exc_info)
+        return (
+            (self.val and is_retryable)
+            or (not self.val and not is_retryable)
+        )
+
+
+class LastAttemptPredicate(object):
+    """
+    A :term:`view predicate` registered as ``tm_last_attempt``. Can be used
+    to determine if an exception view should execute based on whether it's
+    the last attempt by ``pyramid_tm``.
+
+    """
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'tm_last_attempt = %s' % (self.val,)
+
+    phash = text
+
+    def __call__(self, context, request):
+        is_last = is_last_attempt(request)
+        return ((self.val and is_last) or (not self.val and not is_last))
 
 
 def create_tm(request):
@@ -120,9 +293,9 @@ def create_tm(request):
 
 def includeme(config):
     """
-    Set up am implicit 'tween' to do transaction management using the
-    ``transaction`` package.  The tween will be slotted between the main
-    Pyramid app and the Pyramid exception view handler.
+    Set up an implicit 'tween' to do transaction management using the
+    ``transaction`` package.  The tween will be slotted between the Pyramid
+    request ingress and the Pyramid exception view handler.
 
     For every request it handles, the tween will begin a transaction by
     calling ``transaction.begin()``, and will then call the downstream
@@ -140,14 +313,23 @@ def includeme(config):
     - If the deployment configuration specifies a ``tm.commit_veto`` setting,
       and the transaction management tween receives a response from the
       downstream handler, the commit veto hook will be called.  If it returns
-      True, the transaction will be rolled back.  If it returns False, the
+      True, the transaction will be rolled back.  If it returns ``False``, the
       transaction will be committed.
 
-    - If none of the above conditions are True, the transaction will be
+    - If none of the above conditions are true, the transaction will be
       committed (via ``transaction.commit()``).
+
+    This function also sets up two :term:`view predicates <view predicate>`,
+    ``tm_last_attempt=True/False`` and ``tm_exc_is_retryable=True/False``
+    which can be used by views and exception views to determine whether they
+    should execute.
+
     """
-    config.add_request_method('pyramid_tm.create_tm', name='tm', reify=True)
-    config.add_tween('pyramid_tm.tm_tween_factory', under=EXCVIEW)
+    config.add_request_method(create_tm, name='tm', reify=True)
+    config.add_tween('pyramid_tm.tm_tween_factory', over=EXCVIEW)
+    config.add_view_predicate('tm_last_attempt', LastAttemptPredicate)
+    config.add_view_predicate(
+        'tm_exc_is_retryable', RetryableExceptionPredicate)
 
     def ensure():
         manager_hook = config.registry.settings.get("tm.manager_hook")

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import itertools
 import unittest
+import sys
 import transaction
 from transaction import TransactionManager
 from pyramid import testing
@@ -60,8 +62,9 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.txn = DummyTransaction()
         self.request = DummyRequest()
         self.response = DummyResponse()
-        self.registry = DummyRegistry()
-        self.config = testing.setUp()
+        self.config = testing.setUp(request=self.request)
+        self.registry = self.config.registry
+        self.settings = self.registry.settings
 
     def tearDown(self):
         testing.tearDown()
@@ -96,16 +99,16 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertFalse(self.txn.began)
 
     def test_should_activate_true(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'tm.activate_hook':'pyramid_tm.tests.activate_true'})
-        result = self._callFUT(registry=registry)
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
 
     def test_should_activate_false(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'tm.activate_hook':'pyramid_tm.tests.activate_false'})
-        result = self._callFUT(registry=registry)
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertFalse(self.txn.began)
 
@@ -121,12 +124,13 @@ class Test_tm_tween_factory(unittest.TestCase):
         from transaction.interfaces import TransientError
         class Conflict(TransientError):
             pass
-        count = []
+        requests = []
         response = DummyResponse()
-        self.registry.settings['tm.attempts'] = '3'
-        def handler(request, count=count):
-            count.append(True)
-            if len(count) == 3:
+        self.settings['tm.attempts'] = '3'
+        self.config.set_request_factory(lambda e: DummyRequest(environ=e))
+        def handler(request):
+            requests.append(request)
+            if len(requests) == 3:
                 return response
             raise Conflict
         txn = DummyTransaction(retryable=True)
@@ -134,8 +138,11 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertTrue(txn.began)
         self.assertEqual(txn.committed, 1)
         self.assertEqual(txn.aborted, 2)
-        self.assertEqual(self.request.made_seekable, 3)
+        self.assertEqual(self.request.made_seekable, 1)
         self.assertEqual(result, response)
+        self.assertEqual(len(requests), 3)
+        for a, b in itertools.combinations(requests, 2):
+            self.assertNotEqual(a, b)
 
     def test_handler_retryable_exception_defaults_to_1(self):
         from transaction.interfaces import TransientError
@@ -145,6 +152,35 @@ class Test_tm_tween_factory(unittest.TestCase):
         def handler(request, count=count):
             raise Conflict
         self.assertRaises(Conflict, self._callFUT, handler=handler)
+
+    def test_handler_retryable_exception_is_caught(self):
+        from transaction.interfaces import TransientError
+        requests = []
+        response = DummyResponse()
+        self.settings['tm.attempts'] = '3'
+        self.config.set_request_factory(lambda e: DummyRequest(environ=e))
+        class Conflict(TransientError):
+            pass
+        def handler(request):
+            requests.append(request)
+            try:
+                raise Conflict
+            except Conflict as e:
+                # pretend to be the excview tween
+                request.exception = e
+                request.exc_info = sys.exc_info()
+            # pretend to return a response after handling the exception
+            return response
+        txn = DummyTransaction(retryable=True)
+        result = self._callFUT(handler=handler, txn=txn)
+        self.assertTrue(txn.began)
+        self.assertEqual(txn.committed, 0)
+        self.assertEqual(txn.aborted, 3)
+        self.assertEqual(self.request.made_seekable, 1)
+        self.assertEqual(result, response)
+        self.assertEqual(len(requests), 3)
+        for a, b in itertools.combinations(requests, 2):
+            self.assertNotEqual(a, b)
 
     def test_handler_isdoomed(self):
         txn = DummyTransaction(True)
@@ -179,8 +215,8 @@ class Test_tm_tween_factory(unittest.TestCase):
 
     def test_disables_user_annotation(self):
         self.config.testing_securitypolicy(userid="nope")
-        registry = DummyRegistry({"tm.annotate_user": 'false'})
-        result = self._callFUT(registry=registry)
+        self.settings['tm.annotate_user'] = 'false'
+        result = self._callFUT()
         self.assertEqual(self.txn.username, None)
 
     def test_handler_notes(self):
@@ -249,14 +285,14 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertEqual(result, ['active'])
 
     def test_active_flag_not_set_activate_false(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'tm.activate_hook':'pyramid_tm.tests.activate_false'})
         result = []
         def handler(request):
             if 'tm.active' not in request.environ:
                 result.append('not active')
             return self.response
-        self._callFUT(handler=handler, registry=registry)
+        self._callFUT(handler=handler)
         self.assertEqual(result, ['not active'])
 
     def test_active_flag_unset_on_egress(self):
@@ -306,26 +342,24 @@ class Test_tm_tween_factory(unittest.TestCase):
         response.status = '500 Bad Request'
         def handler(request):
             return response
-        registry = DummyRegistry({'tm.commit_veto':None})
-        result = self._callFUT(handler=handler, registry=registry)
+        self.settings.update({'tm.commit_veto':None})
+        result = self._callFUT(handler=handler)
         self.assertEqual(result, response)
         self.assertTrue(self.txn.began)
         self.assertFalse(self.txn.aborted)
         self.assertTrue(self.txn.committed)
 
     def test_commit_veto_true(self):
-        registry = DummyRegistry(
-            {'tm.commit_veto':'pyramid_tm.tests.veto_true'})
-        result = self._callFUT(registry=registry)
+        self.settings.update({'tm.commit_veto':'pyramid_tm.tests.veto_true'})
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
         self.assertTrue(self.txn.aborted)
         self.assertFalse(self.txn.committed)
 
     def test_commit_veto_false(self):
-        registry = DummyRegistry(
-            {'tm.commit_veto':'pyramid_tm.tests.veto_false'})
-        result = self._callFUT(registry=registry)
+        self.settings.update({'tm.commit_veto':'pyramid_tm.tests.veto_false'})
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
         self.assertFalse(self.txn.aborted)
@@ -339,9 +373,9 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertTrue(self.txn.committed)
 
     def test_commit_veto_alias(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'pyramid_tm.commit_veto':'pyramid_tm.tests.veto_true'})
-        result = self._callFUT(registry=registry)
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
         self.assertTrue(self.txn.aborted)
@@ -397,13 +431,17 @@ create_manager = None
 class Test_includeme(unittest.TestCase):
     def test_it(self):
         from pyramid.tweens import EXCVIEW
-        from pyramid_tm import includeme
+        from pyramid_tm import (includeme, create_tm, LastAttemptPredicate,
+                                RetryableExceptionPredicate)
         config = DummyConfig()
         includeme(config)
         self.assertEqual(config.tweens,
-                         [('pyramid_tm.tm_tween_factory', EXCVIEW, None)])
+                         [('pyramid_tm.tm_tween_factory', None, EXCVIEW)])
         self.assertEqual(config.request_methods,
-                         [('pyramid_tm.create_tm', 'tm', True)])
+                         [(create_tm, 'tm', True)])
+        self.assertEqual(config.view_predicates, [
+            ('tm_last_attempt', LastAttemptPredicate, None, None),
+            ('tm_exc_is_retryable', RetryableExceptionPredicate, None, None)])
         self.assertEqual(len(config.actions), 1)
         self.assertEqual(config.actions[0][0], None)
         self.assertEqual(config.actions[0][2], 10)
@@ -483,16 +521,108 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(resp.body, b'failure')
         self.assertEqual(dm.action, 'abort')
 
+    def test_last_attempt_error_view(self):
+        from transaction.interfaces import TransientError
+        class Conflict(TransientError):
+            pass
+        config = self.config
+        requests = []
+        dm = DummyDataManager()
+        def view(request):
+            requests.append(request)
+            dm.bind(request.tm)
+            raise Conflict
+        config.add_view(view)
+        def exc_view(request):
+            return 'failure'
+        def last_exc_view(request):
+            return 'last failure'
+        config.add_settings({'tm.attempts': 2})
+        config.add_view(exc_view, context=Exception, tm_last_attempt=False,
+                        renderer='string')
+        config.add_view(last_exc_view, context=Exception, tm_last_attempt=True,
+                        renderer='string')
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'last failure')
+        self.assertEqual(dm.action, 'abort')
+        self.assertEqual(len(requests), 2)
+
+    def test_last_attempt_true_without_tm(self):
+        config = self.config
+        def view(request):
+            return 'ok'
+        config.add_view(view, tm_last_attempt=True, renderer='string')
+        config.add_settings({'tm.activate_hook': lambda r: False})
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'ok')
+
+    def test_retryable_error_view(self):
+        from transaction.interfaces import TransientError
+        class Conflict(TransientError):
+            pass
+        config = self.config
+        requests = []
+        dm = DummyDataManager()
+        def view(request):
+            requests.append(request)
+            dm.bind(request.tm)
+            if len(requests) == 1:
+                raise Conflict
+            raise ValueError
+        config.add_view(view)
+        def exc_view(request):
+            return 'other failure'
+        def retryable_exc_view(request):
+            return 'retryable failure'
+        config.add_settings({'tm.attempts': 2})
+        config.add_view(exc_view, context=Exception, tm_exc_is_retryable=False,
+                        renderer='string')
+        config.add_view(retryable_exc_view, context=Exception, tm_exc_is_retryable=True,
+                        renderer='string')
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'other failure')
+        self.assertEqual(dm.action, 'abort')
+        self.assertEqual(len(requests), 2)
+
+    def test_retryable_error_predicate_fails_without_exception(self):
+        config = self.config
+        def view(request):
+            return 'normal'
+        def retryable_view(request): # pragma: no cover
+            return 'retryable'
+        config.add_view(view, renderer='string')
+        config.add_view(retryable_view, tm_exc_is_retryable=True)
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'normal')
+
+    def test_retryable_is_false_without_tm(self):
+        from transaction.interfaces import TransientError
+        class Conflict(TransientError):
+            pass
+        config = self.config
+        def view(request):
+            raise Conflict
+        config.add_view(view)
+        def retryable_exc_view(request): # pragma: no cover
+            return 'retryable'
+        def nonretryable_exc_view(request):
+            return 'non retryable'
+        config.add_view(retryable_exc_view, context=Exception,
+                        tm_exc_is_retryable=True)
+        config.add_view(nonretryable_exc_view, context=Exception,
+                        tm_exc_is_retryable=False, renderer='string')
+        config.add_settings({'tm.activate_hook': lambda r: False})
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'non retryable')
+
 class Dummy(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
-
-class DummyRegistry(object):
-    def __init__(self, settings=None):
-        if settings is None:
-            settings = {}
-        self.settings = settings
-
 
 class DummyTransaction(TransactionManager):
     began = False
@@ -513,7 +643,7 @@ class DummyTransaction(TransactionManager):
         if self.active:
             return self.retryable
 
-    def get(self):
+    def get(self): # pragma: no cover
         return self
 
     def setUser(self, name, path='/'):
@@ -574,6 +704,9 @@ class DummyRequest(testing.DummyRequest):
     def make_body_seekable(self):
         self.made_seekable += 1
 
+    def invoke_subrequest(self, request, use_tweens): # pragma: no cover
+        pass
+
 class DummyResponse(object):
     def __init__(self, status='200 OK', headers=None):
         self.status = status
@@ -587,9 +720,14 @@ class DummyConfig(object):
         self.tweens = []
         self.request_methods = []
         self.actions = []
+        self.view_predicates = []
+        self.views = []
 
     def add_tween(self, x, under=None, over=None):
         self.tweens.append((x, under, over))
+
+    def add_view_predicate(self, name, predicate, under=None, over=None):
+        self.view_predicates.append((name, predicate, under, over))
 
     def add_request_method(self, x, name=None, reify=None):
         self.request_methods.append((x, name, reify))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except IOError:
     README = CHANGES = ''
 
 install_requires = [
-    'pyramid>=1.2dev',
+    'pyramid>=1.7b4',
     'transaction',
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     py27,py34,py35,pypy,
-    py27-pyramid{12,13,14,15},
-    py35-pyramid{16,17},
+    py35-pyramid{17},
     docs,
     {py2,py3}-cover,coverage
 
@@ -18,11 +17,6 @@ basepython =
     py3: python3.4
 
 deps =
-    pyramid12: pyramid <= 1.2.99
-    pyramid13: pyramid <= 1.3.99
-    pyramid14: pyramid <= 1.4.99
-    pyramid15: pyramid <= 1.5.99
-    pyramid16: pyramid <= 1.6.99
     pyramid17: pyramid <= 1.7.99
 
 commands =


### PR DESCRIPTION
The goal here is to fix #40 and hopefully before it is done, #41.

This PR will be pyramid_tm 2.0 and will require pyramid 1.7+. The current implementation has exposed a couple bugs in pyramid 1.7 which I've had to fix unfortunately.

This feature depends on `request.invoke_exception_view` introduced in pyramid 1.7 in order to render exception responses AFTER excview has executed. The workflow here is to add an excview (with low priority) that handles any exception and checks for retryability. It then sets state and propagates the response up to the tm which catches and tries again. If attempts is exhausted then the error is rendered using `request.invoke_exception_view`.

This maintains basically all the guarantees of the original pyramid_tm as far as the responses returned with the added benefit that the transaction is still alive during the excview tween.

I've also added a shim such that if the tm is explicitly added under excview like it is now, thinks should sitll work like they did before.

Currently there is no attempt to copy requests between attempts. I'm worried about performance there because a naive approach would always copy the request. I don't know if there's a way around that except when `tm.attempts == 1`. Input would be greatly appreciated.
