### PR TITLE
Raise AttributeError on `request.tm` if tm inactive

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -107,3 +107,4 @@ Contributors
 - Chris McDonough, 2014/11/12
 - Chris Rossi, 2014/11/20
 - Donald Stufft, 2015/02/02
+- Nick Stenning, 2016/09/06


### PR DESCRIPTION
This PR addresses the issue raised in #45.

Raising an `AttributeError` for `request.tm` if the current request doesn't have an active transaction manager makes it much harder for an application to mistakenly get hold of a reference to a transaction manager which is not committed (or rolled back) at the end of the request.

There should never be any need to get a reference to the transaction manager during a request that has been opted out using an `activate_hook`. The ability to do so opens up possibilities for subtle bugs where database sessions are registered with a manager that isn't itself hooked up to the request lifecycle, resulting in leaked references to those sessions inside `zope.sqlalchemy`.

As suggested in #45, this is implemented by adding `tm.active` to the WSGI environment on the way through the tween, and removing it on the way out.