### PR TITLE
Enforce unicode in transaction note

### DIFF
--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -94,7 +94,7 @@ def tm_tween_factory(handler, registry):
                 try:
                     t.note(text_(request.path_info))
                 except UnicodeDecodeError:
-                    t.note("Unable to decode path as unicode")
+                    t.note(text_("Unable to decode path as unicode"))
                 response = handler(request)
                 if manager.isDoomed():
                     raise AbortResponse(response)

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -199,7 +199,7 @@ class Test_tm_tween_factory(unittest.TestCase):
         request = DummierRequest()
 
         self._callFUT(request=request)
-        self.assertEqual(self.txn._note, 'Unable to decode path as unicode')
+        self.assertEqual(self.txn._note, u'Unable to decode path as unicode')
         self.assertEqual(self.txn.user, None)
 
     def test_handler_notes_unicode_path(self):


### PR DESCRIPTION
It looks like something was left over for #49. Without this fix I was having this error:

```
  File "[...]/.venv/local/lib/python2.7/site-packages/pyramid/tweens.py", line 22, in excview_tween
    response = handler(request)
  File "[...]/.venv/local/lib/python2.7/site-packages/pyramid_tm/__init__.py", line 119, in tm_tween
    reraise(*exc_info)
  File "[...]/.venv/local/lib/python2.7/site-packages/pyramid_tm/__init__.py", line 97, in tm_tween
    t.note("Unable to decode path as unicode")
  File "[...]/.venv/local/lib/python2.7/site-packages/transaction/_transaction.py", line 537, in note
    raise TypeError("Note must be text (unicode)")
TypeError: Note must be text (unicode)

```