### PR TITLE
Transaction aware reify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist/
 env*/
 venv/
 .idea/
+
+# pip leaves around
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,6 @@ matrix:
           env: TOXENV=py2-cover,py3-cover,coverage
         - python: 3.5
           env: TOXENV=docs
-        - python: 2.7
-          env: TOXENV=py27-pyramid12
-        - python: 2.7
-          env: TOXENV=py27-pyramid13
-        - python: 2.7
-          env: TOXENV=py27-pyramid14
-        - python: 2.7
-          env: TOXENV=py27-pyramid15
-        - python: 3.5
-          env: TOXENV=py35-pyramid16
         - python: 3.5
           env: TOXENV=py35-pyramid17
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 sudo: false
 
+services:
+  - postgresql
+
 matrix:
     include:
         - python: 2.7
@@ -20,6 +23,9 @@ matrix:
 
 install:
   - travis_retry pip install tox
+
+before_script:
+  - - psql -c 'create database pyramid_tm_integration;' -U postgres
 
 script:
   - travis_retry tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,3 @@ before_script:
 script:
   - travis_retry tox
 
-notifications:
-  email:
-    - pyramid-checkins@lists.repoze.org
-  irc:
-    channels:
-      - "chat.freenode.net#pyramid"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: false
 
+cache: pip
+
 services:
   - postgresql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - travis_retry pip install tox
 
 before_script:
-  - - psql -c 'create database pyramid_tm_integration;' -U postgres
+  - psql -c 'create database pyramid_tm_integration;' -U postgres
 
 script:
   - travis_retry tox

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,3 +13,10 @@
 
 .. autofunction:: create_tm
 
+.. autofunction:: is_exc_retryable
+
+.. autofunction:: is_last_attempt
+
+.. autoclass:: LastAttemptPredicate
+
+.. autoclass:: RetryableExceptionPredicate

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -9,8 +9,20 @@ Glossary
    Pyramid
       A `web framework <http://pylonshq.com/pyramid>`_.
 
+   data manager
+      The ``transaction`` package wraps data managers implemented for
+      different transactional backends, such as SQLAlchemy
+      (``zope.sqlalchemy``), but also many others.
+
+   retryable
+      A retryable exception is any exception that is recognized as retryable
+      by an active :term:`data manager`. These errors usually inherit from
+      ``transaction.interfaces.TransientError``. These errors are temporary
+      and thus marked as retryable. For example, a serialization error in a
+      database resulting from concurrent transactions.
+
    transaction
       A database transaction comprises a unit of work performed within a
       database management system.  In the context of the Pyramid documentation,
-      "transaction" is also the name of a `Python package 
-      <http://pypi.python.org/pypi/transaction>`_ used by pyramid_tm.
+      "transaction" is also the name of a `Python package
+      <http://pypi.python.org/pypi/transaction>`__ used by ``pyramid_tm``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,8 @@
 pyramid_tm
 ==========
 
+.. contents:: :local:
+
 .. _overview: 
 
 Overview
@@ -83,6 +85,16 @@ well as SQLAlchemy connections which are configured with
 ``zope.sqlalchemy.register(session)`` from the `zope.sqlalchemy
 <https://pypi.python.org/pypi/zope.sqlalchemy>`_ package.
 
+Using with Other Tweens
+-----------------------
+
+If any of your tweens uses database they must be placed under ``pyramid_tm``.
+
+Example:
+
+.. code-block:: python
+
+   config.add_tween("myapp.tweens.factory", under="pyramid_tm.tm_tween_factory")
 
 Custom Transaction Managers
 ---------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,42 @@ Example:
 
    config.add_tween("myapp.tweens.factory", under="pyramid_tm.tm_tween_factory")
 
+Accessing Transaction within the Exception View
+-----------------------------------------------
+
+Pyramid provides an exception view that can render HTTP 500 Internal Server
+error page. Depending on the context, which is the exception, it may or
+may not be safe to access transactional data, transaction aware reified
+variables and such in the exception view.
+
+To make sure that your exception view behaves well in the both context
+you can do:
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid_tm.reify can_access_transaction_in_excview
+
+
+   @view_config(context=Exception)
+   def exception_view(context, request):
+       """Example of transaction retry aware exception view.
+
+       :param context: The exception raised in the real view
+       """
+
+       if can_access_transaction_in_excview(context, request):
+           # You can access e.g. request.user that is a transaction aware reified property.
+           # (just demonstrate how to access database inside the exception view handled)
+           print(request.user.id)
+       else:
+           # It is not safe to
+           # May cause SQLAlchemy DetachedInstanceError or
+           # SQLAlchemy OperationalError
+           pass
+
+       return HTTPInternalServerError("It's coming down burning.")
+
 Custom Transaction Managers
 ---------------------------
 

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -14,6 +14,7 @@ from pyramid_tm.compat import reraise
 from pyramid_tm.compat import native_
 
 from pyramid_tm.events import TransactionAttempt
+from pyramid_tm.events import TransactionExceptionRender
 
 
 resolver = DottedNameResolver(None)
@@ -206,6 +207,9 @@ def tm_tween_factory(handler, registry):
 
 
 def render_exception(request, exc_info):
+
+    request.registry.notify(TransactionExceptionRender(request, exc_info))
+
     try:
         return request.invoke_exception_view(exc_info)
     except HTTPNotFound:

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -55,17 +55,10 @@ def tm_tween_factory(handler, registry):
         # Set a flag in the environment to enable the `request.tm` property.
         request.environ['tm.active'] = True
 
-        manager = getattr(request, 'tm', None)
-        if manager is None: # pragma: no cover (pyramid < 1.4)
-            manager = create_tm(request)
-            request.tm = manager
+        manager = request.tm
         number = attempts
         if annotate_user:
-            if hasattr(request, 'unauthenticated_userid'):
-                userid = request.unauthenticated_userid
-            else: # pragma no cover (for pyramid < 1.5)
-                from pyramid.security import unauthenticated_userid
-                userid = unauthenticated_userid(request)
+            userid = request.unauthenticated_userid
         else:
             userid = None
 
@@ -153,14 +146,7 @@ def includeme(config):
     - If none of the above conditions are True, the transaction will be
       committed (via ``transaction.commit()``).
     """
-    # pyramid 1.4+
-    if hasattr(config, 'add_request_method'):
-        config.add_request_method(
-            'pyramid_tm.create_tm', name='tm', reify=True)
-    # pyramid 1.3
-    elif hasattr(config, 'set_request_property'): # pragma: no cover
-        config.set_request_property(
-            'pyramid_tm.create_tm', name='tm', reify=True)
+    config.add_request_method('pyramid_tm.create_tm', name='tm', reify=True)
     config.add_tween('pyramid_tm.tm_tween_factory', under=EXCVIEW)
 
     def ensure():

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -13,6 +13,9 @@ from pyramid.util import DottedNameResolver
 from pyramid_tm.compat import reraise
 from pyramid_tm.compat import native_
 
+from pyramid_tm.events import TransactionAttempt
+
+
 resolver = DottedNameResolver(None)
 
 
@@ -128,6 +131,9 @@ def tm_tween_factory(handler, registry):
                     t.note(native_(request.path_info, 'utf-8'))
                 except UnicodeDecodeError:
                     t.note("Unable to decode path as unicode")
+
+                e = TransactionAttempt(request, t, number)
+                registry.notify(e)
 
                 response = handler(request)
                 if manager.isDoomed():

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -57,6 +57,7 @@ def tm_tween_factory(handler, registry):
     assert attempts > 0
 
     def tm_tween(request):
+
         if (
             # don't handle txn mgmt if repoze.tm is in the WSGI pipeline
             'repoze.tm.active' in request.environ or
@@ -132,7 +133,7 @@ def tm_tween_factory(handler, registry):
                 except UnicodeDecodeError:
                     t.note("Unable to decode path as unicode")
 
-                e = TransactionAttempt(request, t, number)
+                e = TransactionAttempt(request, t, number, attempts)
                 registry.notify(e)
 
                 response = handler(request)
@@ -344,4 +345,3 @@ def includeme(config):
             config.registry.settings["tm.manager_hook"] = manager_hook
 
     config.action(None, ensure, order=10)
-    config.add_directive("add_transaction_aware_request_method", "pyramid_tm.reify.add_transaction_aware_request_method")

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -344,3 +344,4 @@ def includeme(config):
             config.registry.settings["tm.manager_hook"] = manager_hook
 
     config.action(None, ensure, order=10)
+    config.add_directive("add_transaction_aware_request_method", "pyramid_tm.reify.add_transaction_aware_request_method")

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -1,14 +1,20 @@
 import sys
 import transaction
 
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.interfaces import IRequestExtensions
+from pyramid.interfaces import IRequestFactory
+from pyramid.request import Request, apply_request_extensions
 from pyramid.settings import asbool
-from pyramid.util import DottedNameResolver
+from pyramid.threadlocal import manager as request_manager
 from pyramid.tweens import EXCVIEW
+from pyramid.util import DottedNameResolver
 
 from pyramid_tm.compat import reraise
 from pyramid_tm.compat import native_
 
 resolver = DottedNameResolver(None)
+
 
 def default_commit_veto(request, response):
     """
@@ -27,18 +33,24 @@ def default_commit_veto(request, response):
         return xtm != 'commit'
     return response.status.startswith(('4', '5'))
 
-class AbortResponse(Exception):
+
+class AbortWithResponse(Exception):
+    """ Abort the transaction but return a pre-baked response."""
     def __init__(self, response):
         self.response = response
 
+
 def tm_tween_factory(handler, registry):
-    old_commit_veto = registry.settings.get('pyramid_tm.commit_veto', None)
-    commit_veto = registry.settings.get('tm.commit_veto', old_commit_veto)
-    activate = registry.settings.get('tm.activate_hook')
-    attempts = int(registry.settings.get('tm.attempts', 1))
+    settings = registry.settings
+    old_commit_veto = settings.get('pyramid_tm.commit_veto', None)
+    commit_veto = settings.get('tm.commit_veto', old_commit_veto)
+    activate = settings.get('tm.activate_hook')
+    attempts = int(settings.get('tm.attempts', 1))
     commit_veto = resolver.maybe_resolve(commit_veto) if commit_veto else None
     activate = resolver.maybe_resolve(activate) if activate else None
-    annotate_user = asbool(registry.settings.get("tm.annotate_user", True))
+    annotate_user = asbool(settings.get('tm.annotate_user', True))
+    request_factory = registry.queryUtility(IRequestFactory, default=Request)
+    request_extensions = registry.queryUtility(IRequestExtensions)
     assert attempts > 0
 
     def tm_tween(request):
@@ -52,58 +64,219 @@ def tm_tween_factory(handler, registry):
         ):
             return handler(request)
 
-        # Set a flag in the environment to enable the `request.tm` property.
-        request.environ['tm.active'] = True
+        # if we are supporting multiple attempts then we must make
+        # make the body seekable in order to re-use it across multiple
+        # attempts. make_body_seekable will copy wsgi.input if
+        # necessary, otherwise it will rewind the copy to position zero
+        if attempts != 1:
+            request.make_body_seekable()
 
-        manager = request.tm
-        number = attempts
-        if annotate_user:
-            userid = request.unauthenticated_userid
-        else:
-            userid = None
+        # hang onto a reference to the original request as it's the thing
+        # used above the tm tween, we can't change that
+        orig_request = request
+        manager = None
 
-        while number:
-            number -= 1
+        for number in range(attempts):
+            is_last_attempt = (number == attempts - 1)
+
+            # track the attempt info in the environ
+            # try to set it as soon as possible so that it's available
+            # in the request factory and elsewhere if people want it
+            # note: set all of these values here as they are cleared after
+            # each attempt
+            environ = request.environ
+            environ['tm.active'] = True
+            environ['tm.attempt'] = number
+            environ['tm.attempts'] = attempts
+
+            # do not touch request.tm until we've set it active or it'll raise
+            if manager is None:
+                manager = request.tm
+
+            # if we are not on the first attempt then we should start
+            # with a new request object and throw away any changes to
+            # the old object, however we do this carefully to try and
+            # avoid extra copies of the body
+            if number > 0:
+                # try to make sure this code stays in sync with pyramid's
+                # router which normally creates requests
+                request = request_factory(environ)
+                request.tm = manager
+                request.registry = registry
+                request.invoke_subrequest = orig_request.invoke_subrequest
+                apply_request_extensions(request, extensions=request_extensions)
+
+            # push the new request onto the threadlocal stack
+            # this should be safe unless someone is doing something
+            # really funky
+            request_manager.push({
+                'request': request,
+                'registry': registry,
+            })
+
             try:
-                manager.begin()
-                # make_body_seekable will copy wsgi.input if necessary,
-                # otherwise it will rewind the copy to position zero
-                if attempts != 1:
-                    request.make_body_seekable()
-                t = manager.get()
-                if userid:
-                    userid = native_(userid, 'utf-8')
-                    t.setUser(userid, '')
+                t = manager.begin()
+
+                # do not address the authentication policy until we are within
+                # the transaction boundaries
+                if annotate_user:
+                    userid = request.unauthenticated_userid
+                    if userid:
+                        userid = native_(userid, 'utf-8')
+                        t.setUser(userid, '')
                 try:
                     t.note(native_(request.path_info, 'utf-8'))
                 except UnicodeDecodeError:
                     t.note("Unable to decode path as unicode")
+
                 response = handler(request)
                 if manager.isDoomed():
-                    raise AbortResponse(response)
+                    raise AbortWithResponse(response)
+
+                # check for a squashed exception and handle it
+                # this would happen if an exception view was invoked and
+                # rendered an error response
+                exc_info = getattr(request, 'exc_info', None)
+                if exc_info is not None:
+                    # if this was the last attempt or the exception is not
+                    # retryable use this response instead of raising and
+                    # having a new error response generated
+                    if (
+                        is_last_attempt or
+                        not is_exc_retryable(request, exc_info)
+                    ):
+                        raise AbortWithResponse(response)
+
+                    # the exception is retryable so we'll squash the response
+                    # and loop around to try again
+                    else:
+                        reraise(*exc_info)
+
                 if commit_veto is not None:
                     veto = commit_veto(request, response)
                     if veto:
-                        raise AbortResponse(response)
+                        raise AbortWithResponse(response)
                 manager.commit()
-                del request.environ['tm.active']
                 return response
-            except AbortResponse as e:
+
+            except AbortWithResponse as e:
                 manager.abort()
-                del request.environ['tm.active']
                 return e.response
-            except:
+
+            except Exception:
                 exc_info = sys.exc_info()
                 try:
-                    retryable = manager._retryable(*exc_info[:-1])
-                    manager.abort()
-                    if (number <= 0) or (not retryable):
-                        del request.environ['tm.active']
-                        reraise(*exc_info)
+                    # if this was the last attempt or the exception is not
+                    # retryable then make a last ditch effort to render an
+                    # error response before sending the exception up the stack
+                    if (
+                        is_last_attempt or
+                        not is_exc_retryable(request, exc_info)
+                    ):
+                        return render_exception(request, exc_info)
+
                 finally:
+                    # keep the manager alive until after invoke_exception_view
+                    manager.abort()
+
                     del exc_info # avoid leak
 
+            # cleanup any changes we made to the request
+            finally:
+                request_manager.pop()
+
+                del environ['tm.active']
+                del environ['tm.attempt']
+                del environ['tm.attempts']
+
+                # propagate exception info back to the original request,
+                # possibly clearing out a retryable error triggered from the
+                # first attempt
+                orig_request.exception = getattr(request, 'exception', None)
+                orig_request.exc_info = getattr(request, 'exc_info', None)
+
     return tm_tween
+
+
+def render_exception(request, exc_info):
+    try:
+        return request.invoke_exception_view(exc_info)
+    except HTTPNotFound:
+        reraise(*exc_info)
+
+
+def is_exc_retryable(request, exc_info):
+    """
+    Return ``True`` if the exception is recognized as :term:`retryable`.
+
+    This will return ``False`` if ``pyramid_tm`` is inactive for the request.
+
+    """
+    if not request.environ.get('tm.active', False):
+        return False
+    if exc_info is None:
+        return False
+    return request.tm._retryable(*exc_info[:-1])
+
+
+def is_last_attempt(request):
+    """
+    Return ``True`` if the ``request`` is being executed as the last
+    attempt, meaning that ``pyramid_tm`` will not be issuing any new attempts,
+    regardless of what happens when executing this request.
+
+    This will return ``True`` if ``pyramid_tm`` is inactive for the request.
+
+    """
+    environ = request.environ
+    if not environ.get('tm.active', False):
+        return True
+
+    return environ['tm.attempt'] == environ['tm.attempts'] - 1
+
+
+class RetryableExceptionPredicate(object):
+    """
+    A :term:`view predicate` registered as ``tm_exc_is_retryable``. Can be
+    used to determine if an exception view should execute based on whether
+    the exception is :term:`retryable`.
+
+    """
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'tm_exc_is_retryable = %s' % (self.val,)
+
+    phash = text
+
+    def __call__(self, context, request):
+        exc_info = getattr(request, 'exc_info', None)
+        is_retryable = is_exc_retryable(request, exc_info)
+        return (
+            (self.val and is_retryable)
+            or (not self.val and not is_retryable)
+        )
+
+
+class LastAttemptPredicate(object):
+    """
+    A :term:`view predicate` registered as ``tm_last_attempt``. Can be used
+    to determine if an exception view should execute based on whether it's
+    the last attempt by ``pyramid_tm``.
+
+    """
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'tm_last_attempt = %s' % (self.val,)
+
+    phash = text
+
+    def __call__(self, context, request):
+        is_last = is_last_attempt(request)
+        return ((self.val and is_last) or (not self.val and not is_last))
 
 
 def create_tm(request):
@@ -120,9 +293,9 @@ def create_tm(request):
 
 def includeme(config):
     """
-    Set up am implicit 'tween' to do transaction management using the
-    ``transaction`` package.  The tween will be slotted between the main
-    Pyramid app and the Pyramid exception view handler.
+    Set up an implicit 'tween' to do transaction management using the
+    ``transaction`` package.  The tween will be slotted between the Pyramid
+    request ingress and the Pyramid exception view handler.
 
     For every request it handles, the tween will begin a transaction by
     calling ``transaction.begin()``, and will then call the downstream
@@ -140,14 +313,23 @@ def includeme(config):
     - If the deployment configuration specifies a ``tm.commit_veto`` setting,
       and the transaction management tween receives a response from the
       downstream handler, the commit veto hook will be called.  If it returns
-      True, the transaction will be rolled back.  If it returns False, the
+      True, the transaction will be rolled back.  If it returns ``False``, the
       transaction will be committed.
 
-    - If none of the above conditions are True, the transaction will be
+    - If none of the above conditions are true, the transaction will be
       committed (via ``transaction.commit()``).
+
+    This function also sets up two :term:`view predicates <view predicate>`,
+    ``tm_last_attempt=True/False`` and ``tm_exc_is_retryable=True/False``
+    which can be used by views and exception views to determine whether they
+    should execute.
+
     """
-    config.add_request_method('pyramid_tm.create_tm', name='tm', reify=True)
-    config.add_tween('pyramid_tm.tm_tween_factory', under=EXCVIEW)
+    config.add_request_method(create_tm, name='tm', reify=True)
+    config.add_tween('pyramid_tm.tm_tween_factory', over=EXCVIEW)
+    config.add_view_predicate('tm_last_attempt', LastAttemptPredicate)
+    config.add_view_predicate(
+        'tm_exc_is_retryable', RetryableExceptionPredicate)
 
     def ensure():
         manager_hook = config.registry.settings.get("tm.manager_hook")

--- a/pyramid_tm/events.py
+++ b/pyramid_tm/events.py
@@ -15,9 +15,12 @@ class TransactionAttempt(object):
     :param tx: :py:class:`transaction.Transaction` object
 
     :param attempt_no: Integer, 0 is the first request play attempt
+
+    :param attempts: Total number of attempts before pyramid_tm gives up
     """
 
-    def __init__(self, request, tx, attempt_no):
+    def __init__(self, request, tx, attempt_no, attempts):
         self.request = request
         self.tx = tx
         self.attempt_no = attempt_no
+        self.attempts = attempts

--- a/pyramid_tm/events.py
+++ b/pyramid_tm/events.py
@@ -1,0 +1,23 @@
+"""Transaction management related Pyramid events."""
+
+
+class TransactionAttempt(object):
+    """A web serving play will be attempted for a HTTP request.
+
+    This event is fired just before the tween enters to request handling.
+
+    * ``attempt_no == 0`` first attempt
+
+    * ``attempt_no > 0`` any subsequent attempts
+
+    :param request: Pyramid HTTP request object
+
+    :param tx: :py:class:`transaction.Transaction` object
+
+    :param attempt_no: Integer, 0 is the first request play attempt
+    """
+
+    def __init__(self, request, tx, attempt_no):
+        self.request = request
+        self.tx = tx
+        self.attempt_no = attempt_no

--- a/pyramid_tm/events.py
+++ b/pyramid_tm/events.py
@@ -24,3 +24,12 @@ class TransactionAttempt(object):
         self.tx = tx
         self.attempt_no = attempt_no
         self.attempts = attempts
+
+
+
+class TransactionExceptionRender(object):
+    """Triggered before the exception view rendering starts."""
+
+    def __init__(self, request, exc_info):
+        self.request = request
+        self.exc_info = exc_info

--- a/pyramid_tm/events.py
+++ b/pyramid_tm/events.py
@@ -24,3 +24,14 @@ class TransactionAttempt(object):
         self.tx = tx
         self.attempt_no = attempt_no
         self.attempts = attempts
+
+
+class TransactionAborted(object):
+    """We run out of attempts and the request could not be successfully played.
+
+    This event is fired after the transaction has been rolled back. Any access to transaction aware databases should be avoided after this event.
+    """
+
+    def __init__(self, request, tx):
+        self.request = request
+        self.tx = tx

--- a/pyramid_tm/events.py
+++ b/pyramid_tm/events.py
@@ -24,14 +24,3 @@ class TransactionAttempt(object):
         self.tx = tx
         self.attempt_no = attempt_no
         self.attempts = attempts
-
-
-class TransactionAborted(object):
-    """We run out of attempts and the request could not be successfully played.
-
-    This event is fired after the transaction has been rolled back. Any access to transaction aware databases should be avoided after this event.
-    """
-
-    def __init__(self, request, tx):
-        self.request = request
-        self.tx = tx

--- a/pyramid_tm/integrationtests.py
+++ b/pyramid_tm/integrationtests.py
@@ -3,14 +3,11 @@
 See transaction replays and reifiers work correctly with PostgreSQL.
 """
 import threading
-import transaction
 
 import pytest
 import requests
 
 from pyramid.config import Configurator
-from pyramid.registry import Registry
-from sqlalchemy import engine_from_config
 from transaction import TransactionManager
 from webtest.http import StopableWSGIServer
 
@@ -34,6 +31,7 @@ def registry(configurator):
 
 @pytest.fixture
 def app(configurator):
+    configurator.include("pyramid_tm")
     configurator.include(sample)
     return configurator.make_wsgi_app()
 
@@ -49,7 +47,10 @@ def dbsession(request, registry):
 
     engine = sample.create_engine(registry)
 
+    # This is the transaction manager we use for the unit test
+    # main thread
     unit_test_tm = TransactionManager()
+
     dbsession = sample.create_session(registry, engine, unit_test_tm)
 
     with dbsession.tm:
@@ -78,7 +79,7 @@ def user(dbsession):
 
 
 @pytest.fixture
-def web_server(request, app, dbsession):
+def web_server(request, app):
     port = 7788
     server = StopableWSGIServer.create(app, host="localhost", port=port)
     server.wait()
@@ -102,12 +103,54 @@ class SimulatenousRequestThread(threading.Thread):
         self.result = self.func()
 
 
-def test_replay(web_server):
-    """Check simple conflict."""
+def test_resolvable(web_server, user, dbsession):
+    """Check for a conflict the pyramid_tm can resolve.
+
+    We are configured to two replay attempts.
+    """
+
+    sample.reset_test_counters()
 
     def hit_user():
         return requests.get(web_server + "/hit_user")
 
+    # Do some concurrent database transactions
+    t1 = SimulatenousRequestThread(hit_user)
+    t2 = SimulatenousRequestThread(hit_user)
+
+    t1.start()
+    t2.start()
+
+    t1.join()
+    t2.join()
+
+    # All request should have passed as 200
+    for t in (t1, t2):
+        assert t.result.status_code == 200
+
+    # The view should be hit three times
+    # 1. first transaction success
+    # 2. second transaction conflict
+    # 3. second transaction success
+    assert sample.hit_views == 3
+
+    with dbsession.tm:
+        # The database counted correctly
+        user = dbsession.query(sample.User).one()
+        assert user.counter == 2
+
+
+def test_unresolvable(web_server, user, dbsession):
+    """Check for a conflict the pyramid_tm fails to resolve after retry attempt exceeed.
+    We are configured to two replay attempts.
+    """
+
+    sample.reset_test_counters()
+
+    def hit_user():
+        return requests.get(web_server + "/hit_user")
+
+    # Do some concurrent database transactions
     t1 = SimulatenousRequestThread(hit_user)
     t2 = SimulatenousRequestThread(hit_user)
     t3 = SimulatenousRequestThread(hit_user)
@@ -120,5 +163,30 @@ def test_replay(web_server):
     t2.join()
     t3.join()
 
-    results = [t1.result, t2.result, t3.result]
-    print(results)
+    threads = (t1, t2, t3)
+
+    success_count = sum(1 for t in threads if t.result.status_code == 200)
+    fail_count = sum(1 for t in threads if t.result.status_code == 500)
+
+    # 2 out of 3 requests OK
+    assert success_count == 2
+
+    # This one could not be replayed
+    assert fail_count == 1
+
+    # The view should be hit three times
+    # 1. first transaction success
+    # 2. second transaction conflict
+    # 3. second transaction success
+    # 4. third transaction conflict
+    # 5. third transaction conflict again
+    assert sample.hit_views == 5
+
+    # When the last transaction runs out of attempts in ends
+    # up the exception view
+    assert sample.exceptions_views == 1
+
+    with dbsession.tm:
+        # The database counted correctly
+        user = dbsession.query(sample.User).one()
+        assert user.counter == 2

--- a/pyramid_tm/integrationtests.py
+++ b/pyramid_tm/integrationtests.py
@@ -1,0 +1,104 @@
+"""Functional test suite to ensure transactions are correctly replayed.
+
+See transaction replays and reifiers work correctly with PostgreSQL.
+"""
+import threading
+import transaction
+
+import pytest
+import requests
+
+from pyramid.config import Configurator
+from webtest.http import StopableWSGIServer
+
+from pyramid_tm import sample
+
+
+@pytest.fixture
+def settings():
+    return {
+        "sqlalchemy.url": "postgresql://localhost/pyramid_tm_functional"
+    }
+
+
+@pytest.fixture
+def app(settings):
+    config = Configurator(settings)
+    config.scan(sample)
+    return config.make_wsgi_app()
+
+
+@pytest.fixture
+def dbsession(request, config):
+    """An SQLAlchemy session you can access from the unit test thread.
+
+    Also resets database between subsequent test runs.
+    """
+
+    Base = sample.Base
+
+    connection = engine.connect()
+
+    with transaction.manager:
+        Base.metadata.drop_all(engine)
+        Base.metadata.create_all(engine)
+
+    def teardown():
+        with transaction.manager:
+            Base.metadata.drop_all(engine)
+
+        dbsession.close()
+
+    request.addfinalizer(teardown)
+
+    return dbsession
+
+
+@pytest.fixture
+def user(config):
+    """Make sure database is initialized and we have one and only one User there."""
+    return config.make_wsgi_app()
+
+
+@pytest.fixture(scope="session")
+def web_server(request, app, dbsession, users):
+    port = 7788
+    server = StopableWSGIServer.create(app, host="localhost", port=port)
+    server.wait()
+
+    def teardown():
+        # Shutdown server thread
+        server.shutdown()
+
+    request.addfinalizer(teardown)
+    host_base = "http://localhost:7788"
+    return host_base
+
+
+class SimulatenousRequestThread(threading.Thread):
+
+    def __init__(self, func):
+        super(SimulatenousRequestThread, self).__init__()
+        self.func = func
+
+    def run(self):
+        self.result = self.func()
+
+
+def test_replay(web_server):
+    """Check simple conflict."""
+
+    def hit_user():
+        return requests.get(web_server + "/hit_user")
+
+    t1 = SimulatenousRequestThread(hit_user)
+    t2 = SimulatenousRequestThread(hit_user)
+    t3 = SimulatenousRequestThread(hit_user)
+
+    t1.start()
+    t2.start()
+    t3.start()
+
+    t1.join()
+    t2.join()
+    t3.join()

--- a/pyramid_tm/integrationtests.py
+++ b/pyramid_tm/integrationtests.py
@@ -1,6 +1,6 @@
-"""Functional test suite to ensure transactions are correctly replayed.
+"""A test suite exercising full stack integration.
 
-See transaction replays and reifiers work correctly with PostgreSQL.
+See transaction replays and reifiers work correctly with PostgreSQL, Pyramid, pyramid_tm and zope.sqlalchemy.
 """
 import threading
 

--- a/pyramid_tm/integrationtests.py
+++ b/pyramid_tm/integrationtests.py
@@ -180,6 +180,7 @@ def test_unresolvable(web_server, user, dbsession):
     # 3. second transaction success
     # 4. third transaction conflict
     # 5. third transaction conflict again
+    # -> third transaction out of replay attempts
     assert sample.hit_views == 5
 
     # When the last transaction runs out of attempts in ends

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -1,5 +1,46 @@
 """Transaction aware reify helpers."""
+from pyramid.events import subscriber
 
-def add_tm_aware_reify():
-    pass
+from .events import TransactionAttempt
 
+
+_marker = object()
+
+
+def _subscribe_transaction_replay(config):
+    config.add_subscriber(on_transaction_attempt_reset_reify, TransactionAttempt)
+    config.registry._transaction_aware_request_registered = True
+
+
+def transaction_aware_reify(
+        config,
+        callable,
+        name=None):
+    """Make a request property reified in a transaction aware manner.
+
+    TODO: This could not be made a config directive, as having feature parity with add_request_method would force us to touch a lot of Pyramid internal APIs.
+    """
+
+    if name is None:
+        name = callable.__name__
+
+    def _reify(request):
+        # Check if we have reified this result for this play
+        result = request._transaction_properties.get(name, _marker)
+        if result is _marker:
+            # Perform expensive transaction aware computation
+            result = request._transaction_properties[name] = callable()
+        return result
+
+    # Register our transaction event handler
+    if getattr(config.registry, "_transaction_aware_request_registered", None) is None:
+        _subscribe_transaction_replay(config)
+
+    config.add_request_method(_reify, name)
+
+
+@subscriber(TransactionAttempt)
+def on_transaction_attempt_reset_reify(e):
+    # This is the internal map where we are store reified results
+    # over the request play
+    e.request._transaction_properties = {}

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -18,6 +18,23 @@ def transaction_aware_reify(
         name=None):
     """Make a request property reified in a transaction aware manner.
 
+    Use this reifier for database aware request properties.
+
+    IF there is a replay attempt due to a transaction conflict the result of the reified data is reset and looked up again on the next request play.
+
+    Example:
+
+    .. code-block:: python
+
+        def get_user(request):
+            return request.dbsession.query(User).one_or_none()
+
+        config.add_request_method(
+            callable=transaction_aware_reify(config, get_user),
+            name="user",
+            property=True,
+            reify=False)
+
     TODO: This could not be made a config directive, as having feature parity with add_request_method would force us to touch a lot of Pyramid internal APIs.
     """
 

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -1,0 +1,5 @@
+"""Transaction aware reify helpers."""
+
+def add_tm_aware_reify():
+    pass
+

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -61,6 +61,8 @@ def transaction_aware_reify(
         if result is _marker:
             # Perform expensive transaction aware computation
             result = request._transaction_properties[name] = callable(request)
+            #print("Updated ", request.path, request._transaction_properties, request.tm._txn)
+            #print("Got ", request.path, request._transaction_properties)
         return result
 
     # Register our transaction event handler
@@ -72,6 +74,7 @@ def transaction_aware_reify(
 
 @subscriber(TransactionAttempt)
 def on_transaction_attempt_reset_reify(e):
+    """Make sure we reset all reified properties if there is a replay."""
     reset_transaction_aware_properties(e.request)
 
 
@@ -82,6 +85,7 @@ def reset_transaction_aware_properties(request):
     """
     # This is the internal map where we are store reified results
     # over the request play
+    #print("Resetting ", getattr(request, "_transaction_properties", None))
     request._transaction_properties = {}
 
 

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -29,14 +29,14 @@ def transaction_aware_reify(
         result = request._transaction_properties.get(name, _marker)
         if result is _marker:
             # Perform expensive transaction aware computation
-            result = request._transaction_properties[name] = callable()
+            result = request._transaction_properties[name] = callable(request)
         return result
 
     # Register our transaction event handler
     if getattr(config.registry, "_transaction_aware_request_registered", None) is None:
         _subscribe_transaction_replay(config)
 
-    config.add_request_method(_reify, name)
+    return _reify
 
 
 @subscriber(TransactionAttempt)

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -26,6 +26,8 @@ def transaction_aware_reify(
 
     .. code-block:: python
 
+        from pyramid_tm.reify import transaction_aware_reify
+
         def get_user(request):
             return request.dbsession.query(User).one_or_none()
 
@@ -49,6 +51,10 @@ def transaction_aware_reify(
 
     def _reify(request):
         # Check if we have reified this result for this play
+
+        if not hasattr(request, "_transaction_properties"):
+            raise RuntimeError("There was an attempt to access transaction aware reified request property. However, for this request we never received transaction start event. This is usually a sign of incorrect tween stack order. Make sure pyramid_tm is the bottom-most tween before any tween accesses database. You can use ptweens command for this.")
+
         result = request._transaction_properties.get(name, _marker)
         if result is _marker:
             # Perform expensive transaction aware computation

--- a/pyramid_tm/reify.py
+++ b/pyramid_tm/reify.py
@@ -36,6 +36,12 @@ def transaction_aware_reify(
             reify=False)
 
     TODO: This could not be made a config directive, as having feature parity with add_request_method would force us to touch a lot of Pyramid internal APIs.
+
+    :param config: Instance of :py:class:`pyramid.config.Configurator`
+
+    :param callable: A function that takes ``request`` as a first arguments and plays around transaction aware stuff like databases
+
+    :param name: (Optional) used internally to the reified stored value map
     """
 
     if name is None:

--- a/pyramid_tm/sample.py
+++ b/pyramid_tm/sample.py
@@ -99,10 +99,11 @@ def hit_user(request):
 
 
 @view_config(context=Exception)
-def exception_view(request):
+def exception_view(context, request):
     """This is were we end up if the transaction conflict cannot be resolved."""
     global exceptions_views
     exceptions_views += 1
+    print("Exceptinon fall through", context)  # TODO: Debug travis
     return HTTPInternalServerError("Ei mennyt niin kuin strömsöössä")
 
 

--- a/pyramid_tm/sample.py
+++ b/pyramid_tm/sample.py
@@ -1,0 +1,63 @@
+"""Functional test suite code."""
+import random
+import time
+from pyramid.view import view_config
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    )
+
+from sqlalchemy.ext.declarative import declarative_base
+
+from sqlalchemy.orm import (
+    scoped_session,
+    sessionmaker,
+    )
+
+from zope.sqlalchemy import ZopeTransactionExtension
+
+DBSession = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+
+Base = declarative_base()
+
+# How many time we hit different end points for a request
+hit_views = 0
+exceptions_views = 0
+
+
+class User(Base):
+    """Our poor user who is going be a very conflicted person."""
+
+    __tablename__ = 'user'
+
+    id = Column(Integer, primary_key=True)
+
+    username = Column(String, unique=True)
+
+    #: Used to see all requests go through
+    counter = Column(Integer, default=0)
+
+
+@view_config(route_name="hit_user")
+def hit_user(request):
+    """A view point hammering user, with random delays to simulate transaction conflict."""
+    user = request.user
+    user.counter += 1
+    time.sleep(0.1 + random.random(0.5))
+
+    global hit_views
+    hit_views += 1
+
+
+@view_config(route_name="exception_view")
+def exception_view(request):
+    """A view point hammering user, with random delays to simulate transaction conflict."""
+    user = request.user
+    user.counter += 1
+    time.sleep(0.1 + random.random(0.5))
+
+    global hit_views
+    hit_views += 1
+
+

--- a/pyramid_tm/sample.py
+++ b/pyramid_tm/sample.py
@@ -1,4 +1,5 @@
-"""Functional test suite code."""
+"""Integration example code."""
+
 import random
 import time
 from pyramid.view import view_config
@@ -7,17 +8,24 @@ from sqlalchemy import (
     Integer,
     String,
     )
+from sqlalchemy import engine_from_config
 
 from sqlalchemy.ext.declarative import declarative_base
 
 from sqlalchemy.orm import (
-    scoped_session,
     sessionmaker,
     )
+from websauna.system.model.meta import get_engine
 
-from zope.sqlalchemy import ZopeTransactionExtension
+import zope.sqlalchemy
 
-DBSession = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+from pyramid_tm.reify import transaction_aware_reify
+
+
+CONFIG = {
+    "sqlalchemy.url": "postgresql://localhost/pyramid_tm_integration"
+}
+
 
 Base = declarative_base()
 
@@ -37,6 +45,37 @@ class User(Base):
 
     #: Used to see all requests go through
     counter = Column(Integer, default=0)
+
+
+def create_engine(registry):
+    engine = engine_from_config(registry.settings, 'sqlalchemy.', client_encoding='utf8', isolation_level='SERIALIZABLE')
+
+
+def create_session(registry, engine, transaction_manager):
+    """Create a new database session from a process specific connection pool."""
+
+    # Make sure we create session maker only once per process,
+    # as otherwise SQLAlchemy connection pooling doesn't work.
+    # We assume the lifecycle of the registry matches the life cycle
+    # of SQLAlchemy process pool.
+    db_session_maker = getattr(registry, "db_session_maker", None)
+
+    if not db_session_maker:
+        engine = get_engine(registry.settings)
+
+        dbmaker = sessionmaker()
+        dbmaker.configure(bind=engine)
+
+        db_session_maker = registry.db_session_maker = dbmaker
+
+    # Pull out a new session from a connection pool
+    dbsession = db_session_maker()
+    zope.sqlalchemy.register(dbsession, transaction_manager=transaction_manager)
+
+    # Expose transaction manager with the dbsession
+    dbsession.tm = transaction_manager
+
+    return dbsession
 
 
 @view_config(route_name="hit_user")
@@ -61,3 +100,26 @@ def exception_view(request):
     hit_views += 1
 
 
+def includeme(config):
+    from pyramid_tm import sample
+
+    def dbsession(request):
+        engine = create_engine(request.registry)
+        return create_session(request.registry, engine, request.tm)
+
+    def get_user(request):
+        # Assume our database has 0..1 users
+        return request.dbsession.query(User).one_or_none()
+
+    config.add_route("hit_user", "/hit_user")
+    config.add_route("exception_view", "/exception_view")
+    config.add_request_method(dbsession, "dbsession", reify=True)
+    config.add_request_method(transaction_aware_reify(config, get_user), "user", reify=False)
+    config.scan(sample)
+
+
+def reset_test_counts():
+    global hit_views
+    global exceptions_views
+    hit_views = 0
+    exceptions_views = 0

--- a/pyramid_tm/sample.py
+++ b/pyramid_tm/sample.py
@@ -103,7 +103,7 @@ def exception_view(context, request):
     """This is were we end up if the transaction conflict cannot be resolved."""
     global exceptions_views
     exceptions_views += 1
-    print("Exceptinon fall through", context)  # TODO: Debug travis
+    print("Exception fall through", context)  # This is to debug Travis
     return HTTPInternalServerError("Ei mennyt niin kuin strömsöössä")
 
 

--- a/pyramid_tm/sample.py
+++ b/pyramid_tm/sample.py
@@ -18,7 +18,6 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import (
     sessionmaker,
     )
-from websauna.system.model.meta import get_engine
 
 import zope.sqlalchemy
 
@@ -70,7 +69,7 @@ def create_session(registry, engine, transaction_manager):
     db_session_maker = getattr(registry, "db_session_maker", None)
 
     if not db_session_maker:
-        engine = get_engine(registry.settings)
+        engine = create_engine(registry)
 
         dbmaker = sessionmaker()
         dbmaker.configure(bind=engine)

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import itertools
 import unittest
+import sys
 import transaction
 from transaction import TransactionManager
 from pyramid import testing
@@ -60,8 +62,9 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.txn = DummyTransaction()
         self.request = DummyRequest()
         self.response = DummyResponse()
-        self.registry = DummyRegistry()
-        self.config = testing.setUp()
+        self.config = testing.setUp(request=self.request)
+        self.registry = self.config.registry
+        self.settings = self.registry.settings
 
     def tearDown(self):
         testing.tearDown()
@@ -96,16 +99,16 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertFalse(self.txn.began)
 
     def test_should_activate_true(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'tm.activate_hook':'pyramid_tm.tests.activate_true'})
-        result = self._callFUT(registry=registry)
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
 
     def test_should_activate_false(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'tm.activate_hook':'pyramid_tm.tests.activate_false'})
-        result = self._callFUT(registry=registry)
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertFalse(self.txn.began)
 
@@ -121,12 +124,13 @@ class Test_tm_tween_factory(unittest.TestCase):
         from transaction.interfaces import TransientError
         class Conflict(TransientError):
             pass
-        count = []
+        requests = []
         response = DummyResponse()
-        self.registry.settings['tm.attempts'] = '3'
-        def handler(request, count=count):
-            count.append(True)
-            if len(count) == 3:
+        self.settings['tm.attempts'] = '3'
+        self.config.set_request_factory(lambda e: DummyRequest(environ=e))
+        def handler(request):
+            requests.append(request)
+            if len(requests) == 3:
                 return response
             raise Conflict
         txn = DummyTransaction(retryable=True)
@@ -134,8 +138,11 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertTrue(txn.began)
         self.assertEqual(txn.committed, 1)
         self.assertEqual(txn.aborted, 2)
-        self.assertEqual(self.request.made_seekable, 3)
+        self.assertEqual(self.request.made_seekable, 1)
         self.assertEqual(result, response)
+        self.assertEqual(len(requests), 3)
+        for a, b in itertools.combinations(requests, 2):
+            self.assertNotEqual(a, b)
 
     def test_handler_retryable_exception_defaults_to_1(self):
         from transaction.interfaces import TransientError
@@ -145,6 +152,35 @@ class Test_tm_tween_factory(unittest.TestCase):
         def handler(request, count=count):
             raise Conflict
         self.assertRaises(Conflict, self._callFUT, handler=handler)
+
+    def test_handler_retryable_exception_is_caught(self):
+        from transaction.interfaces import TransientError
+        requests = []
+        response = DummyResponse()
+        self.settings['tm.attempts'] = '3'
+        self.config.set_request_factory(lambda e: DummyRequest(environ=e))
+        class Conflict(TransientError):
+            pass
+        def handler(request):
+            requests.append(request)
+            try:
+                raise Conflict
+            except Conflict as e:
+                # pretend to be the excview tween
+                request.exception = e
+                request.exc_info = sys.exc_info()
+            # pretend to return a response after handling the exception
+            return response
+        txn = DummyTransaction(retryable=True)
+        result = self._callFUT(handler=handler, txn=txn)
+        self.assertTrue(txn.began)
+        self.assertEqual(txn.committed, 0)
+        self.assertEqual(txn.aborted, 3)
+        self.assertEqual(self.request.made_seekable, 1)
+        self.assertEqual(result, response)
+        self.assertEqual(len(requests), 3)
+        for a, b in itertools.combinations(requests, 2):
+            self.assertNotEqual(a, b)
 
     def test_handler_isdoomed(self):
         txn = DummyTransaction(True)
@@ -179,8 +215,8 @@ class Test_tm_tween_factory(unittest.TestCase):
 
     def test_disables_user_annotation(self):
         self.config.testing_securitypolicy(userid="nope")
-        registry = DummyRegistry({"tm.annotate_user": 'false'})
-        result = self._callFUT(registry=registry)
+        self.settings['tm.annotate_user'] = 'false'
+        result = self._callFUT()
         self.assertEqual(self.txn.username, None)
 
     def test_handler_notes(self):
@@ -249,14 +285,14 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertEqual(result, ['active'])
 
     def test_active_flag_not_set_activate_false(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'tm.activate_hook':'pyramid_tm.tests.activate_false'})
         result = []
         def handler(request):
             if 'tm.active' not in request.environ:
                 result.append('not active')
             return self.response
-        self._callFUT(handler=handler, registry=registry)
+        self._callFUT(handler=handler)
         self.assertEqual(result, ['not active'])
 
     def test_active_flag_unset_on_egress(self):
@@ -306,26 +342,24 @@ class Test_tm_tween_factory(unittest.TestCase):
         response.status = '500 Bad Request'
         def handler(request):
             return response
-        registry = DummyRegistry({'tm.commit_veto':None})
-        result = self._callFUT(handler=handler, registry=registry)
+        self.settings.update({'tm.commit_veto':None})
+        result = self._callFUT(handler=handler)
         self.assertEqual(result, response)
         self.assertTrue(self.txn.began)
         self.assertFalse(self.txn.aborted)
         self.assertTrue(self.txn.committed)
 
     def test_commit_veto_true(self):
-        registry = DummyRegistry(
-            {'tm.commit_veto':'pyramid_tm.tests.veto_true'})
-        result = self._callFUT(registry=registry)
+        self.settings.update({'tm.commit_veto':'pyramid_tm.tests.veto_true'})
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
         self.assertTrue(self.txn.aborted)
         self.assertFalse(self.txn.committed)
 
     def test_commit_veto_false(self):
-        registry = DummyRegistry(
-            {'tm.commit_veto':'pyramid_tm.tests.veto_false'})
-        result = self._callFUT(registry=registry)
+        self.settings.update({'tm.commit_veto':'pyramid_tm.tests.veto_false'})
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
         self.assertFalse(self.txn.aborted)
@@ -339,9 +373,9 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertTrue(self.txn.committed)
 
     def test_commit_veto_alias(self):
-        registry = DummyRegistry(
+        self.settings.update(
             {'pyramid_tm.commit_veto':'pyramid_tm.tests.veto_true'})
-        result = self._callFUT(registry=registry)
+        result = self._callFUT()
         self.assertEqual(result, self.response)
         self.assertTrue(self.txn.began)
         self.assertTrue(self.txn.aborted)
@@ -397,13 +431,17 @@ create_manager = None
 class Test_includeme(unittest.TestCase):
     def test_it(self):
         from pyramid.tweens import EXCVIEW
-        from pyramid_tm import includeme
+        from pyramid_tm import (includeme, create_tm, LastAttemptPredicate,
+                                RetryableExceptionPredicate)
         config = DummyConfig()
         includeme(config)
         self.assertEqual(config.tweens,
-                         [('pyramid_tm.tm_tween_factory', EXCVIEW, None)])
+                         [('pyramid_tm.tm_tween_factory', None, EXCVIEW)])
         self.assertEqual(config.request_methods,
-                         [('pyramid_tm.create_tm', 'tm', True)])
+                         [(create_tm, 'tm', True)])
+        self.assertEqual(config.view_predicates, [
+            ('tm_last_attempt', LastAttemptPredicate, None, None),
+            ('tm_exc_is_retryable', RetryableExceptionPredicate, None, None)])
         self.assertEqual(len(config.actions), 1)
         self.assertEqual(config.actions[0][0], None)
         self.assertEqual(config.actions[0][2], 10)
@@ -483,16 +521,108 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(resp.body, b'failure')
         self.assertEqual(dm.action, 'abort')
 
+    def test_last_attempt_error_view(self):
+        from transaction.interfaces import TransientError
+        class Conflict(TransientError):
+            pass
+        config = self.config
+        requests = []
+        dm = DummyDataManager()
+        def view(request):
+            requests.append(request)
+            dm.bind(request.tm)
+            raise Conflict
+        config.add_view(view)
+        def exc_view(request):
+            return 'failure'
+        def last_exc_view(request):
+            return 'last failure'
+        config.add_settings({'tm.attempts': 2})
+        config.add_view(exc_view, context=Exception, tm_last_attempt=False,
+                        renderer='string')
+        config.add_view(last_exc_view, context=Exception, tm_last_attempt=True,
+                        renderer='string')
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'last failure')
+        self.assertEqual(dm.action, 'abort')
+        self.assertEqual(len(requests), 2)
+
+    def test_last_attempt_true_without_tm(self):
+        config = self.config
+        def view(request):
+            return 'ok'
+        config.add_view(view, tm_last_attempt=True, renderer='string')
+        config.add_settings({'tm.activate_hook': lambda r: False})
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'ok')
+
+    def test_retryable_error_view(self):
+        from transaction.interfaces import TransientError
+        class Conflict(TransientError):
+            pass
+        config = self.config
+        requests = []
+        dm = DummyDataManager()
+        def view(request):
+            requests.append(request)
+            dm.bind(request.tm)
+            if len(requests) == 1:
+                raise Conflict
+            raise ValueError
+        config.add_view(view)
+        def exc_view(request):
+            return 'other failure'
+        def retryable_exc_view(request):
+            return 'retryable failure'
+        config.add_settings({'tm.attempts': 2})
+        config.add_view(exc_view, context=Exception, tm_exc_is_retryable=False,
+                        renderer='string')
+        config.add_view(retryable_exc_view, context=Exception, tm_exc_is_retryable=True,
+                        renderer='string')
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'other failure')
+        self.assertEqual(dm.action, 'abort')
+        self.assertEqual(len(requests), 2)
+
+    def test_retryable_error_predicate_fails_without_exception(self):
+        config = self.config
+        def view(request):
+            return 'normal'
+        def retryable_view(request): # pragma: no cover
+            return 'retryable'
+        config.add_view(view, renderer='string')
+        config.add_view(retryable_view, tm_exc_is_retryable=True)
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'normal')
+
+    def test_retryable_is_false_without_tm(self):
+        from transaction.interfaces import TransientError
+        class Conflict(TransientError):
+            pass
+        config = self.config
+        def view(request):
+            raise Conflict
+        config.add_view(view)
+        def retryable_exc_view(request): # pragma: no cover
+            return 'retryable'
+        def nonretryable_exc_view(request):
+            return 'non retryable'
+        config.add_view(retryable_exc_view, context=Exception,
+                        tm_exc_is_retryable=True)
+        config.add_view(nonretryable_exc_view, context=Exception,
+                        tm_exc_is_retryable=False, renderer='string')
+        config.add_settings({'tm.activate_hook': lambda r: False})
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'non retryable')
+
 class Dummy(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
-
-class DummyRegistry(object):
-    def __init__(self, settings=None):
-        if settings is None:
-            settings = {}
-        self.settings = settings
-
 
 class DummyTransaction(TransactionManager):
     began = False
@@ -513,7 +643,7 @@ class DummyTransaction(TransactionManager):
         if self.active:
             return self.retryable
 
-    def get(self):
+    def get(self): # pragma: no cover
         return self
 
     def setUser(self, name, path='/'):
@@ -574,6 +704,9 @@ class DummyRequest(testing.DummyRequest):
     def make_body_seekable(self):
         self.made_seekable += 1
 
+    def invoke_subrequest(self, request, use_tweens): # pragma: no cover
+        pass
+
 class DummyResponse(object):
     def __init__(self, status='200 OK', headers=None):
         self.status = status
@@ -587,9 +720,14 @@ class DummyConfig(object):
         self.tweens = []
         self.request_methods = []
         self.actions = []
+        self.view_predicates = []
+        self.views = []
 
     def add_tween(self, x, under=None, over=None):
         self.tweens.append((x, under, over))
+
+    def add_view_predicate(self, name, predicate, under=None, over=None):
+        self.view_predicates.append((name, predicate, under, over))
 
     def add_request_method(self, x, name=None, reify=None):
         self.request_methods.append((x, name, reify))

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,15 @@ tests_require = [
     'WebTest',
 ]
 
+integration_tests_require = [
+    'WebTest',
+    'requests',
+    'zope.sqlalchemy',
+    'psycopg2',
+    "py.test",
+]
+
+
 testing_extras = tests_require + ['nose', 'coverage']
 docs_extras = [
     'Sphinx',
@@ -71,7 +80,8 @@ setup(name='pyramid_tm',
       test_suite="pyramid_tm",
       entry_points='',
       extras_require = {
-          'testing':testing_extras,
-          'docs':docs_extras,
+          'testing': testing_extras,
+          'integration_testing': integration_tests_require,
+          'docs': docs_extras,
           },
       )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ integration_tests_require = [
     'requests',
     'zope.sqlalchemy',
     'psycopg2',
-    "py.test",
+    "pytest",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except IOError:
     README = CHANGES = ''
 
 install_requires = [
-    'pyramid>=1.2dev',
+    'pyramid>=1.7b4',
     'transaction',
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     py27,py34,py35,pypy,
-    py27-pyramid{12,13,14,15},
-    py35-pyramid{16,17},
+    py35-pyramid{17},
     docs,
     {py2,py3}-cover,coverage
 
@@ -18,11 +17,6 @@ basepython =
     py3: python3.4
 
 deps =
-    pyramid12: pyramid <= 1.2.99
-    pyramid13: pyramid <= 1.3.99
-    pyramid14: pyramid <= 1.4.99
-    pyramid15: pyramid <= 1.5.99
-    pyramid16: pyramid <= 1.6.99
     pyramid17: pyramid <= 1.7.99
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 commands =
     pip install pyramid_tm[testing,integration_testing]
 #    nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
-    py.test pyramid_tm/integrationtests.py
+    py.test -s pyramid_tm/integrationtests.py
 
 [testenv:docs]
 basepython = python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,9 @@ deps =
     pyramid17: pyramid <= 1.7.99
 
 commands =
-    pip install pyramid_tm[testing]
+    pip install pyramid_tm[testing,integration_testing]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
+    py.test pyramid_tm/integrationtests
 
 [testenv:docs]
 basepython = python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 
 commands =
     pip install pyramid_tm[testing,integration_testing]
-    nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
+#    nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
     py.test pyramid_tm/integrationtests
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 commands =
     pip install pyramid_tm[testing,integration_testing]
 #    nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
-    py.test pyramid_tm/integrationtests
+    py.test pyramid_tm/integrationtests.py
 
 [testenv:docs]
 basepython = python3.5


### PR DESCRIPTION
This PR provides 

*  Transaction aware way to do reified request propeties (request.user)

* PostgreSQL based integration test suite for a full Pyramid + SQLAlchemy stack 

* It also shows how to set up  a SQLAlchemy and zope.sqlalchemy stack without using thread locals

The work is based on  https://github.com/Pylons/pyramid_tm/pull/42

Currently issues

- I did not create `config.add_transaction_aware_request_method` as  `config.add_request_method` internals would need to be copied over. They were complex and referred to a lot of Pyramid internal APIs. Instead we have a pattern:

```python
        def get_user(request):
            return request.dbsession.query(User).one_or_none()

        config.add_request_method(
            callable=transaction_aware_reify(config, get_user),
            name="user",
            property=True,
            reify=False)

```

- Could not get the existing test suite to run on Travis, so it is commented out currently

- Python 2.7 fails with `TypeError('Note must be text (unicode)`


