### PR TITLE
render exception views for errors caused by commit/abort

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 -------
 
+unreleased
+^^^^^^^^^^
+
+- On Pyramid >= 1.7 any errors raised from ``pyramid_tm`` invoking
+  ``request.tm.abort`` and ``request.tm.commit`` will be caught and used
+  to lookup and execute an exception view to return an error response. This
+  exception view will be executed with an inactive transaction manager.
+  See https://github.com/Pylons/pyramid_tm/pull/61
+
 2.0 (2017-04-11)
 ^^^^^^^^^^^^^^^^
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,3 +16,5 @@
 .. autofunction:: create_tm
 
 .. autofunction:: explicit_manager
+
+.. autoclass:: TMActivePredicate

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -1,5 +1,6 @@
 import sys
 from pyramid.exceptions import ConfigurationError
+from pyramid.exceptions import NotFound
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 from pyramid.util import DottedNameResolver
@@ -57,6 +58,48 @@ def tm_tween_factory(handler, registry):
                       'setting in version 2.0. To re-enable retry support '
                       'add pyramid_retry to your application.')
 
+    # define a finish function that we'll call from every branch to
+    # commit or abort the transaction - this can't be in a finally because
+    # we only want the finisher to wrap commit/abort which occur in several
+    # disparate branches below and we want to avoid catching errors from
+    # non commit/abort related operations
+    def _finish(request, finisher, response=None):
+        # ensure the manager is inactive prior to invoking the finisher
+        # such that when we handle any possible exceptions it is ready
+        environ = request.environ
+        if 'tm.active' in environ:
+            del environ['tm.active']
+        if 'tm.manager' in environ:
+            del environ['tm.manager']
+
+        try:
+            finisher()
+
+        # catch any errors that occur specifically during commit/abort
+        # and attempt to render them to a response
+        except Exception:
+            exc_info = sys.exc_info()
+            try:
+                if hasattr(request, 'invoke_exception_view'):  # pyramid >= 1.7
+                    response = request.invoke_exception_view(exc_info)
+
+                else:  # pragma: no cover
+                    raise NotFound
+
+            except NotFound:
+                # since commit/abort has already been executed it's highly
+                # likely we will not detect any backend-specific retryable
+                # issues here unless they directly subclass TransientError
+                # since the manager has cleared its list of data mangers at
+                # this point
+                maybe_tag_retryable(request, exc_info)
+                reraise(*exc_info)
+
+            finally:
+                del exc_info  # avoid leak
+
+        return response
+
     def tm_tween(request):
         environ = request.environ
         if (
@@ -76,9 +119,9 @@ def tm_tween_factory(handler, registry):
         environ['tm.active'] = True
         environ['tm.manager'] = manager
 
-        try:
-            t = manager.begin()
+        t = manager.begin()
 
+        try:
             # do not address the authentication policy until we are within
             # the transaction boundaries
             if annotate_user:
@@ -106,28 +149,29 @@ def tm_tween_factory(handler, registry):
                 veto = commit_veto(request, response)
                 if veto:
                     raise AbortWithResponse(response)
-            manager.commit()
-            return response
+            return _finish(request, manager.commit, response)
 
         except AbortWithResponse as e:
-            manager.abort()
-            return e.response
+            return _finish(request, manager.abort, e.response)
 
+        # an unhandled exception was propagated - we should abort the
+        # transaction and re-raise the original exception
         except Exception:
             exc_info = sys.exc_info()
             try:
+                # try to tag the original exception as retryable before
+                # aborting the transaction because after abort it may not
+                # be possible to determine if the exception is retryable
+                # because the bound data managers are cleared
                 maybe_tag_retryable(request, exc_info)
+
+                exc_response = _finish(request, manager.abort)
+                if exc_response is not None:
+                    return exc_response
                 reraise(*exc_info)
 
             finally:
-                manager.abort()
-
-                del exc_info # avoid leak
-
-        # cleanup any changes we made to the request
-        finally:
-            del environ['tm.active']
-            del environ['tm.manager']
+                del exc_info  # avoid leak
 
     return tm_tween
 

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -209,6 +209,13 @@ def is_tm_active(request):
     Return ``True`` if the ``request`` is currently being managed by
     the pyramid_tm tween. If ``False`` then it may be necessary to manage
     transactions yourself.
+
+    .. note::
+
+       This does **not** indicate that there is a current transaction. For
+       example, ``request.tm.get()`` may raise a ``NoTransaction`` error even
+       though ``is_tm_active`` returns ``True``. This would be caused by user
+       code that manually completed a transaction and did not begin a new one.
     """
     return request.environ.get('tm.active', False)
 

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -416,6 +416,19 @@ def skip_if_missing(module):  # pragma: no cover
         return wrapped
     return wrapper
 
+def skip_if_package_lt(pkg, version):  # pragma: no cover
+    import pkg_resources
+    def wrapper(fn):
+        dist = pkg_resources.get_distribution(pkg)
+        if dist.parsed_version < pkg_resources.parse_version(version):
+            return
+
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            return fn(*args, **kwargs)
+        return wrapped
+    return wrapper
+
 class TestIntegration(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp(autocommit=False)
@@ -570,6 +583,7 @@ class TestIntegration(unittest.TestCase):
         else:  # pragma: no cover
             raise AssertionError
 
+    @skip_if_package_lt('pyramid', '1.7')
     def test_excview_rendered_after_failed_commit(self):
         config = self.config
         tm = DummyTransaction(finish_with_exc=ValueError)
@@ -582,6 +596,7 @@ class TestIntegration(unittest.TestCase):
         resp = app.get('/')
         self.assertEqual(resp.body, b'failure')
 
+    @skip_if_package_lt('pyramid', '1.7')
     def test_excview_rendered_after_failed_abort(self):
         config = self.config
         tm = DummyTransaction(finish_with_exc=ValueError)
@@ -595,6 +610,7 @@ class TestIntegration(unittest.TestCase):
         resp = app.get('/')
         self.assertEqual(resp.body, b'failure')
 
+    @skip_if_package_lt('pyramid', '1.7')
     def test_excview_rendered_after_failed_abort_from_uncaught_exc(self):
         config = self.config
         tm = DummyTransaction(finish_with_exc=ValueError)


### PR DESCRIPTION
The biggest issue with moving `pyramid_tm` OVER the exception view tween was that errors caused by commit/abort were no longer caught and handled. This PR fixes that issue by wrapping commit/abort operations and using `request.invoke_exception_view` to turn those errors into responses. It is careful not to catch any other errors and allows them to propagate after successful abort.

This feature only works on Pyramid >= 1.7 where `request.invoke_exception_view` was added.