### PR TITLE
allow the commit_veto to handle squashed exceptions

### DIFF
--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -137,18 +137,18 @@ def tm_tween_factory(handler, registry):
             if manager.isDoomed():
                 raise AbortWithResponse(response)
 
-            # check for a squashed exception and handle it
-            # this would happen if an exception view was invoked and
-            # rendered an error response
-            exc_info = getattr(request, 'exc_info', None)
-            if exc_info is not None:
-                maybe_tag_retryable(request, exc_info)
-                raise AbortWithResponse(response)
-
             if commit_veto is not None:
-                veto = commit_veto(request, response)
-                if veto:
+                if commit_veto(request, response):
                     raise AbortWithResponse(response)
+            else:
+                # check for a squashed exception and handle it
+                # this would happen if an exception view was invoked and
+                # rendered an error response
+                exc_info = getattr(request, 'exc_info', None)
+                if exc_info is not None:
+                    maybe_tag_retryable(request, exc_info)
+                    raise AbortWithResponse(response)
+
             return _finish(request, manager.commit, response)
 
         except AbortWithResponse as e:


### PR DESCRIPTION
Basically this allows the `commit_veto` to decide to commit a transaction even if the request contains a squashed exception.

This change is bw-incompatible for anyone using a commit_veto as the veto will now be consulted for some requests that previously (all the way back to pyramid_tm 1.x) were simply aborted.

I think this is a nice balance - pyramid_tm still has no hook in which you can specify that you want to commit an unhandled exception but I feel like that's alright. The advantage of this particular PR is that `HTTPFound` etc are currently squashed by Pyramid and that fact combined with this change is that the veto hook could allow those to be committed. I'd even consider making the `default_commit_veto` the default for pyramid_tm and pushing a 3.0. I'd only change the veto if it was configured to abort on 4xx/5xx **and** `request.exception` was not `None` (currently it aborts without checking `request.exception`.

fixes #64