### PR TITLE
Mark TransientError retryable

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,3 +109,4 @@ Contributors
 - Donald Stufft, 2015/02/02
 - Nick Stenning, 2016/09/06
 - Steve Piercy, 2016/11/19
+- Sean Hammond, 2019/09/27

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -13,6 +13,13 @@ try:
 except ImportError:  # pragma: no cover
     IRetryableError = zope.interface.Interface
 
+try:
+    from pyramid_retry import mark_error_retryable
+except ImportError:  # pragma: no cover
+    mark_error_retryable = lambda error: None
+
+mark_error_retryable(transaction.interfaces.TransientError)
+
 from .compat import reraise
 from .compat import text_
 


### PR DESCRIPTION
If you raise a `TransientError` subclass then your request *will* be retried but pyramid_retry functions like `is_error_retryable()` will incorrectly return `False`.

Mark `TransientError` as retryable so that `is_error_retryable()` correctly returns `True`.

Fixes https://github.com/Pylons/pyramid_tm/issues/70