### PR TITLE
provide a way to override the tm via the environ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ unreleased
 - Allow overriding ``pyramid_tm`` via the environ for testing purposes.
   See https://github.com/Pylons/pyramid_tm/pull/72
 
+- When ``tm.annotate_user`` is enabled, use ``request.authenticated_userid``
+  instead of ``request.unauthenticated_userid``. The latter is deprecated in
+  Pyramid 2.0.
+  See https://github.com/Pylons/pyramid_tm/pull/72
+
 2.3 (2019-09-30)
 ^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 -------
 
+unreleased
+^^^^^^^^^^
+
+- Allow overriding ``pyramid_tm`` via the environ for testing purposes.
+  See https://github.com/Pylons/pyramid_tm/pull/72
+
 2.3 (2019-09-30)
 ^^^^^^^^^^^^^^^^
 

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -209,12 +209,16 @@ def maybe_tag_retryable(request, exc_info):
 
 
 def create_tm(request):
+    manager = request.environ.get('tm.manager')
+    if manager:
+        return manager
+
     manager_hook = request.registry.settings.get('tm.manager_hook')
     if manager_hook:
         manager_hook = resolver.maybe_resolve(manager_hook)
         return manager_hook(request)
-    else:
-        return transaction.manager
+
+    return transaction.manager
 
 
 def is_tm_active(request):

--- a/pyramid_tm/__init__.py
+++ b/pyramid_tm/__init__.py
@@ -132,7 +132,7 @@ def tm_tween_factory(handler, registry):
             # do not address the authentication policy until we are within
             # the transaction boundaries
             if annotate_user:
-                userid = request.unauthenticated_userid
+                userid = request.authenticated_userid
                 if userid:
                     t.user = text_(userid)
             try:

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -330,7 +330,6 @@ class Test_create_tm(unittest.TestCase):
         # Get rid of the request.tm attribute since it shouldn't be here yet.
         del self.request.tm
 
-
     def tearDown(self):
         testing.tearDown()
 
@@ -343,10 +342,15 @@ class Test_create_tm(unittest.TestCase):
     def test_default_threadlocal(self):
         self.assertTrue(self._callFUT() is transaction.manager)
 
-    def test_overridden_manager(self):
+    def test_overridden_manager_hook(self):
         txn = DummyTransaction()
         self.request.registry.settings["tm.manager_hook"] = lambda r: txn
         self.assertTrue(self._callFUT() is txn)
+
+    def test_overridden_manager_environ(self):
+        tm = transaction.TransactionManager(explicit=True)
+        self.request.environ['tm.manager'] = tm
+        self.assertTrue(self._callFUT() is tm)
 
 def veto_true(request, response):
     return True

--- a/pyramid_tm/tests.py
+++ b/pyramid_tm/tests.py
@@ -135,24 +135,24 @@ class Test_tm_tween_factory(unittest.TestCase):
         self.assertTrue(txn.aborted)
         self.assertFalse(txn.committed)
 
-    def test_handler_w_native_unauthenticated_userid(self):
+    def test_handler_w_native_authenticated_userid(self):
         self.config.testing_securitypolicy(userid='phred')
         self._callFUT()
         self.assertEqual(self.txn.user, u'phred')
 
-    def test_handler_w_utf8_unauthenticated_userid(self):
+    def test_handler_w_utf8_authenticated_userid(self):
         USERID = b'phred/\xd1\x80\xd0\xb5\xd1\x81'.decode('utf-8')
         self.config.testing_securitypolicy(userid=USERID)
         self._callFUT()
         self.assertEqual(self.txn.user, u'phred/рес')
 
-    def test_handler_w_latin1_unauthenticated_userid(self):
+    def test_handler_w_latin1_authenticated_userid(self):
         USERID = b'\xc4\xd6\xdc'
         self.config.testing_securitypolicy(userid=USERID)
         self._callFUT()
         self.assertEqual(self.txn.user, u'ÄÖÜ')
 
-    def test_handler_w_integer_unauthenticated_userid(self):
+    def test_handler_w_integer_authenticated_userid(self):
         # See https://github.com/Pylons/pyramid_tm/issues/28
         USERID = 1234
         self.config.testing_securitypolicy(userid=USERID)


### PR DESCRIPTION
This is useful in a functional test suite where you want to control the transactions externally to the wsgi stack. If you coordinate this with your data managers, you can share them all across requests which can be really handy.

```python
@pytest.fixture
def testapp():
    app = ...
    tm = transaction.TransactionManager(explicit=True)
    tm.begin()
    tm.doom()

    testapp = TestApp(app, extra_environ={
        'tm.active': True,    # disable pyramid_tm
        'tm.manager': tm,    # pass in our own tm for the app to use
    })

    yield testapp

    tm.abort()
```