### PR TITLE
Upgrade Python support to 3.9

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,6 +20,7 @@ jobs:
                     - "3.6"
                     - "3.7"
                     - "3.8"
+                    - "3.9"
                     - "pypy3"
                 os:
                     - "ubuntu-latest"
@@ -61,10 +62,10 @@ jobs:
               with:
                   python-version: 2.7
                   architecture: x64
-            - name: Setup python 3.8
+            - name: Setup python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
                   architecture: x64
 
             - run: pip install tox
@@ -77,7 +78,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
                   architecture: x64
             - run: pip install tox
             - run: tox -e docs
@@ -89,7 +90,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
                   architecture: x64
             - run: pip install tox
             - run: tox -e lint

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,3 +110,4 @@ Contributors
 - Nick Stenning, 2016/09/06
 - Steve Piercy, 2016/11/19
 - Sean Hammond, 2019/09/27
+- Jon Betts, 2021/04/19

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist =
     lint,
     py27,pypy,
     py27-pyramid15,
-    py35,py36,py37,py38,pypy3,
+    py35,py36,py37,py38,py39,pypy3,
     py35-pyramid15,
-    py38-pyramid110,
+    py{38,39}-pyramid110,
     docs,
     coverage
 isolated_build = True


### PR DESCRIPTION
This updates the Python support to include 3.9. The dependencies are:

* `pyramid` - Supports 3.9
* `transaction` - Locally tested to support 3.9 (https://github.com/zopefoundation/transaction/pull/100)