### PR TITLE
Fix dead link to transaction docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Overview
 the active :term:`transaction` as provided by the Python `transaction 
 <https://pypi.org/project/transaction/>`_ package. (See the `documentation
 for the transaction package 
-<https://zodb.readthedocs.io/en/latest/transactions.html>`_ for an
+<https://transaction.readthedocs.io/en/latest/>`_ for an
 explanation of what "joining the active transaction" means).
 
 Installation


### PR DESCRIPTION
The ZODB link in the docs is dead. I assume the original target page is still available under

https://zodb.org/en/latest/articles/old-guide/transactions.html

however the URL indicates it may not be for much longer. I guess linking to the transaction docs instead would make sense.