### PR TITLE
Fix retrying transaction when a datamanger marks an exception as retryable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Unreleased (2022-11-14)
 
 - rename "master" to "main"
 
+- Fix retrying transactions with `pyramid_retry` when using veto and a datamanger
+  marks the exception as retryable.
+
 2.5 (2022-03-12)
 ^^^^^^^^^^^^^^^^
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -112,3 +112,4 @@ Contributors
 - Sean Hammond, 2019/09/27
 - Jon Betts, 2021/04/19
 - Jonathan Vanasco, 2022/11/14
+- Christian Zagrodnick, 2024/11/04

--- a/src/pyramid_tm/__init__.py
+++ b/src/pyramid_tm/__init__.py
@@ -149,13 +149,14 @@ def tm_tween_factory(handler, registry):
             if commit_veto is not None:
                 if commit_veto(request, response):
                     raise AbortWithResponse(response)
-            else:
-                # check for a squashed exception and handle it
-                # this would happen if an exception view was invoked and
-                # rendered an error response
-                exc_info = getattr(request, 'exc_info', None)
-                if exc_info is not None:
-                    maybe_tag_retryable(request, exc_info)
+
+            # check for a squashed exception and handle it
+            # this would happen if an exception view was invoked and
+            # rendered an error response
+            exc_info = getattr(request, 'exc_info', None)
+            if exc_info is not None:
+                maybe_tag_retryable(request, exc_info)
+                if commit_veto is None:
                     raise AbortWithResponse(response)
 
             return _finish(request, manager.commit, response)


### PR DESCRIPTION
When using a datamanger to determine if an exception could be retried (e.g. zope.sqlalchemy) and having registered a veto function, transactions were never retried.